### PR TITLE
chore(tests): Django-style test DB safeguard for PG matrix

### DIFF
--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -54,6 +54,7 @@ dev = [
     "pytest-cov>=5.0",
     "ruff>=0.8",
     "mypy>=1.10",
+    "types-PyYAML>=6.0",
     "python-dotenv>=1.0",
     "httpx>=0.27",
 ]

--- a/packages/python/tests/integration/conftest.py
+++ b/packages/python/tests/integration/conftest.py
@@ -20,6 +20,23 @@ The matrix exists because the original tz-naive bug shipped specifically
 because no integration test exercised Postgres — without this, the same
 class of regression can re-enter unnoticed.
 
+## Test database safety (Django-style)
+
+Tests are destructive — schema gets dropped and recreated, rows get
+``TRUNCATE``-d between tests. Pointing them at a dev or prod database
+deletes data. To prevent that, the URL handed to ``DENDRUX_TEST_PG_URL``
+is auto-rewritten so the database name always ends in ``_test``:
+
+    DENDRUX_TEST_PG_URL=postgresql+asyncpg://u:p@host:5432/dendrux
+    # ↓ auto-rewritten to ↓
+    postgresql+asyncpg://u:p@host:5432/dendrux_test
+
+The rewrite emits a one-line warning the first time it kicks in. The
+``dendrux_test`` database is created automatically on first use (via the
+maintenance ``postgres`` database on the same host); subsequent runs
+reuse it. A hard guardrail refuses to proceed if the final DB name does
+not end in ``_test`` — there is no escape hatch on purpose.
+
 To run the matrix locally:
 
     DENDRUX_TEST_PG_URL=postgresql+asyncpg://user:pw@host:5432/dbname \\
@@ -32,7 +49,10 @@ dev with no Postgres still gets a green suite).
 from __future__ import annotations
 
 import os
+import re
+import sys
 from typing import TYPE_CHECKING
+from urllib.parse import urlparse, urlunparse
 
 import pytest
 import pytest_asyncio
@@ -50,6 +70,86 @@ if TYPE_CHECKING:
 
 
 _PG_URL_ENV = "DENDRUX_TEST_PG_URL"
+_TEST_DB_SUFFIX = "_test"
+_DB_NAME_RE = re.compile(r"^[A-Za-z0-9_]+$")
+_REWRITE_WARNED = False
+
+
+def _rewrite_to_test_db(url: str) -> tuple[str, str, bool]:
+    """Ensure URL points at a ``*_test`` database.
+
+    Returns ``(rewritten_url, db_name, was_rewritten)``. Rewrites the URL's
+    database name by appending ``_test`` if it doesn't already end that way.
+    Validates the final name matches ``[A-Za-z0-9_]+`` so it can be safely
+    interpolated into ``CREATE DATABASE`` (asyncpg/PG don't bind-parameterize
+    DDL identifiers).
+    """
+    parsed = urlparse(url)
+    db_name = parsed.path.lstrip("/")
+    if not db_name:
+        raise pytest.UsageError(f"{_PG_URL_ENV} has no database name in path: {url!r}")
+
+    rewritten = False
+    if not db_name.endswith(_TEST_DB_SUFFIX):
+        db_name = f"{db_name}{_TEST_DB_SUFFIX}"
+        parsed = parsed._replace(path=f"/{db_name}")
+        url = urlunparse(parsed)
+        rewritten = True
+
+    if not _DB_NAME_RE.match(db_name):
+        raise pytest.UsageError(
+            f"{_PG_URL_ENV} database name {db_name!r} contains characters "
+            f"outside [A-Za-z0-9_]; refuse to interpolate into DDL."
+        )
+    if not db_name.endswith(_TEST_DB_SUFFIX):
+        # Belt + suspenders — the rewrite above guarantees this, but keep
+        # the assert so a future refactor can't regress the safety property.
+        raise pytest.UsageError(
+            f"{_PG_URL_ENV} resolved DB name {db_name!r} does not end in "
+            f"{_TEST_DB_SUFFIX!r} — refusing to run destructive tests against it."
+        )
+    return url, db_name, rewritten
+
+
+async def _ensure_test_db_exists(url: str, db_name: str) -> None:
+    """``CREATE DATABASE {db_name}`` on the maintenance DB if missing.
+
+    Connects to ``postgres`` (the standard maintenance database) on the same
+    host with AUTOCOMMIT — PG forbids ``CREATE DATABASE`` inside a transaction.
+    Idempotent: if the DB already exists, this is a no-op.
+    """
+    parsed = urlparse(url)
+    maintenance_url = urlunparse(parsed._replace(path="/postgres"))
+
+    eng = create_async_engine(maintenance_url, isolation_level="AUTOCOMMIT", poolclass=NullPool)
+    try:
+        async with eng.connect() as conn:
+            result = await conn.execute(
+                text("SELECT 1 FROM pg_database WHERE datname = :name"),
+                {"name": db_name},
+            )
+            if result.first() is None:
+                # db_name is validated against _DB_NAME_RE above; safe to interpolate.
+                await conn.execute(text(f'CREATE DATABASE "{db_name}"'))
+    finally:
+        await eng.dispose()
+
+
+def _resolve_pg_url() -> str | None:
+    """Read env, rewrite to ``*_test``, validate. Returns URL or None if unset."""
+    global _REWRITE_WARNED
+    raw = os.environ.get(_PG_URL_ENV)
+    if not raw:
+        return None
+    url, db_name, rewritten = _rewrite_to_test_db(raw)
+    if rewritten and not _REWRITE_WARNED:
+        sys.stderr.write(
+            f"\n[dendrux tests] {_PG_URL_ENV} rewritten to use database "
+            f"{db_name!r} (tests are destructive — never run them against a "
+            f"non-{_TEST_DB_SUFFIX} database).\n"
+        )
+        _REWRITE_WARNED = True
+    return url
 
 
 def _engine_params() -> list:
@@ -59,7 +159,7 @@ def _engine_params() -> list:
     # decided. (CI sets it via the workflow `env:` block, locally the
     # caller exports it.)
     sqlite_param = pytest.param("sqlite", id="sqlite")
-    if os.environ.get(_PG_URL_ENV):
+    if _resolve_pg_url() is not None:
         return [sqlite_param, pytest.param("postgres", id="postgres")]
     return [
         sqlite_param,
@@ -98,10 +198,15 @@ async def _pg_schema_setup() -> AsyncIterator[None]:
     # scoped ``engine`` fixture takes it as a positional dep purely to
     # establish ordering — schema must be in place before any test
     # tries to TRUNCATE it.
-    url = os.environ.get(_PG_URL_ENV)
+    url = _resolve_pg_url()
     if not url:
         yield
         return
+
+    # Auto-create the *_test database if missing — Django-style. Connects
+    # to the postgres maintenance DB on the same host. See module docstring.
+    _, db_name, _ = _rewrite_to_test_db(os.environ[_PG_URL_ENV])
+    await _ensure_test_db_exists(url, db_name)
 
     # NullPool: this engine only runs DDL once and is disposed; we don't
     # want it holding pooled connections bound to the session loop.
@@ -129,7 +234,7 @@ async def engine(request, _pg_schema_setup) -> AsyncIterator[AsyncEngine]:
     backend = request.param
 
     if backend == "postgres":
-        url = os.environ.get(_PG_URL_ENV)
+        url = _resolve_pg_url()
         if not url:
             pytest.skip(f"{_PG_URL_ENV} not set")
         # Fresh engine in this test's event loop — asyncpg connections

--- a/packages/python/tests/unit/test_read_router.py
+++ b/packages/python/tests/unit/test_read_router.py
@@ -386,7 +386,10 @@ class TestSseGenerator:
             await internal_store.save_run_event("r1", event_type="run.completed", sequence_index=0)
 
         write_task = asyncio.create_task(_write_later())
-        frame = await asyncio.wait_for(gen.__anext__(), timeout=2.0)
+        # 10s timeout (not 2s) — CI runners have asyncio scheduling jitter
+        # that occasionally pushes the poll-write race past a tight budget.
+        # The test still proves liveness; the deadline is just headroom.
+        frame = await asyncio.wait_for(gen.__anext__(), timeout=10.0)
         await write_task
         await gen.aclose()
 
@@ -401,7 +404,7 @@ class TestSseGenerator:
         await internal_store.create_run("r1", "Agent")
 
         gen = _rr._sse_event_generator(store, "r1", cursor=None)
-        frame = await asyncio.wait_for(gen.__anext__(), timeout=2.0)
+        frame = await asyncio.wait_for(gen.__anext__(), timeout=10.0)
         await gen.aclose()
 
         assert frame.startswith(": keepalive")

--- a/packages/python/tests/unit/test_test_db_safeguard.py
+++ b/packages/python/tests/unit/test_test_db_safeguard.py
@@ -1,0 +1,54 @@
+"""Tests for the integration conftest's Django-style test DB safeguard.
+
+The conftest rewrites DENDRUX_TEST_PG_URL so the database name always
+ends in ``_test``, preventing accidental destruction of dev/prod data.
+These tests cover the URL-rewrite helper in isolation; the auto-create
+side (``_ensure_test_db_exists``) is exercised by the actual PG matrix.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.integration.conftest import _rewrite_to_test_db
+
+
+class TestRewriteToTestDb:
+    def test_appends_test_suffix_when_missing(self):
+        url, db_name, rewritten = _rewrite_to_test_db(
+            "postgresql+asyncpg://user:pw@host:5432/dendrux"
+        )
+        assert db_name == "dendrux_test"
+        assert url == "postgresql+asyncpg://user:pw@host:5432/dendrux_test"
+        assert rewritten is True
+
+    def test_passes_through_when_already_test(self):
+        url, db_name, rewritten = _rewrite_to_test_db(
+            "postgresql+asyncpg://user:pw@host:5432/dendrux_test"
+        )
+        assert db_name == "dendrux_test"
+        assert url == "postgresql+asyncpg://user:pw@host:5432/dendrux_test"
+        assert rewritten is False
+
+    def test_preserves_query_string_and_credentials(self):
+        original = "postgresql+asyncpg://u:p@h:5432/myapp?sslmode=require"
+        url, db_name, rewritten = _rewrite_to_test_db(original)
+        assert db_name == "myapp_test"
+        assert "sslmode=require" in url
+        assert "u:p@h:5432" in url
+        assert rewritten is True
+
+    def test_rejects_url_with_no_db_name(self):
+        with pytest.raises(pytest.UsageError, match="no database name"):
+            _rewrite_to_test_db("postgresql+asyncpg://user:pw@host:5432/")
+
+    def test_rejects_db_name_with_unsafe_characters(self):
+        # Hostile name that survives appending _test would still trip the
+        # alphanumeric-only check — DDL identifiers can't be bind-parameterized.
+        with pytest.raises(pytest.UsageError, match="outside"):
+            _rewrite_to_test_db('postgresql+asyncpg://u:p@h:5432/foo";DROP TABLE users;--')
+
+    def test_arbitrary_app_name_gets_test_suffix(self):
+        _, db_name, rewritten = _rewrite_to_test_db("postgresql+asyncpg://u:p@h:5432/excel_agent")
+        assert db_name == "excel_agent_test"
+        assert rewritten is True


### PR DESCRIPTION
## Summary                                                                                                                
                                                                                                                            
  - Auto-rewrite `DENDRUX_TEST_PG_URL` so the database name always ends in `_test` (`dendrux` → `dendrux_test`). Prevents   
  the destructive PG matrix from dropping a dev or prod database.                                                           
  - Auto-create the `*_test` database on first run via the `postgres` maintenance DB. Idempotent.                           
  - Hard guardrail: refuse to proceed if the final DB name doesn't end in `_test`. No escape hatch on purpose.              
  - One-line warning at session start the first time the rewrite kicks in.                                                
                                                        
  Mirrors Django's test-DB convention. Industry standard for the lightweight-Python-with-real-PG case.
                                                                                                                            
  ## Test plan                                   
                                                                                                                            
  - [x] Unit tests for `_rewrite_to_test_db`                                                                              
  - [x] `make ci` with `DENDRUX_TEST_PG_URL=...../dendrux` → rewrites to `dendrux_test`, all 1631 tests pass                
  - [x] Verified locally: `dendrux_test` auto-created, dev `dendrux` DB untouched
  - [ ] CI green (PR check)     