### PR TITLE
feat: add guardrail_findings kwarg to LoopNotifier.on_llm_call_completed

### DIFF
--- a/packages/python/src/dendrux/loops/_helpers.py
+++ b/packages/python/src/dendrux/loops/_helpers.py
@@ -156,6 +156,7 @@ async def notify_llm(
     semantic_messages: list[Message] | None = None,
     semantic_tools: list[ToolDef] | None = None,
     duration_ms: int | None = None,
+    guardrail_findings: dict[str, Any] | None = None,
 ) -> None:
     """Notify notifier of an LLM call completion, swallowing exceptions."""
     if notifier is None:
@@ -167,6 +168,7 @@ async def notify_llm(
             semantic_messages=semantic_messages,
             semantic_tools=semantic_tools,
             duration_ms=duration_ms,
+            guardrail_findings=guardrail_findings,
         )
     except Exception:
         logger.warning("Notifier.on_llm_call_completed failed", exc_info=True)

--- a/packages/python/src/dendrux/loops/base.py
+++ b/packages/python/src/dendrux/loops/base.py
@@ -119,6 +119,7 @@ class LoopNotifier(Protocol):
         semantic_messages: list[Message] | None = None,
         semantic_tools: list[ToolDef] | None = None,
         duration_ms: int | None = None,
+        guardrail_findings: dict[str, Any] | None = None,
     ) -> None:
         """Called after provider.complete() returns.
 
@@ -129,6 +130,12 @@ class LoopNotifier(Protocol):
 
         Args:
             duration_ms: Wall-clock time for the provider.complete() call.
+            guardrail_findings: Detector hits from the incoming + outgoing
+                guardrail scans for this LLM call (None when no guardrails
+                or no hits). Mirrors :class:`LoopRecorder.on_llm_call_completed`
+                so notifiers (OTel, dashboards, webhooks) can attach
+                guardrail context to LLM events without joining through
+                the separate ``guardrail.*`` governance event stream.
         """
         ...
 

--- a/packages/python/src/dendrux/loops/react.py
+++ b/packages/python/src/dendrux/loops/react.py
@@ -758,6 +758,7 @@ class ReActLoop(Loop):
                         semantic_messages=messages,
                         semantic_tools=tools,
                         duration_ms=llm_duration_ms,
+                        guardrail_findings=_all_guardrail_findings or None,
                     )
                     _accumulate_usage(total_usage, response.usage)
                     await _check_budget(
@@ -811,6 +812,7 @@ class ReActLoop(Loop):
                 semantic_messages=messages,
                 semantic_tools=tools,
                 duration_ms=llm_duration_ms,
+                guardrail_findings=_all_guardrail_findings or None,
             )
             _accumulate_usage(total_usage, response.usage)
             await _check_budget(

--- a/packages/python/src/dendrux/loops/single.py
+++ b/packages/python/src/dendrux/loops/single.py
@@ -316,6 +316,7 @@ class SingleCall(Loop):
                     semantic_messages=messages,
                     semantic_tools=None,
                     duration_ms=llm_duration_ms,
+                    guardrail_findings=_sc_findings or None,
                 )
                 await _check_budget(
                     agent.budget,
@@ -365,6 +366,7 @@ class SingleCall(Loop):
             semantic_messages=messages,
             semantic_tools=None,
             duration_ms=llm_duration_ms,
+            guardrail_findings=_sc_findings or None,
         )
 
         assistant_msg = Message(role=Role.ASSISTANT, content=response.text or "")

--- a/packages/python/src/dendrux/notifiers/composite.py
+++ b/packages/python/src/dendrux/notifiers/composite.py
@@ -42,6 +42,7 @@ class CompositeNotifier(LoopNotifier):
         semantic_messages: list[Message] | None = None,
         semantic_tools: list[ToolDef] | None = None,
         duration_ms: int | None = None,
+        guardrail_findings: dict[str, Any] | None = None,
     ) -> None:
         for notifier in self._notifiers:
             try:
@@ -51,6 +52,7 @@ class CompositeNotifier(LoopNotifier):
                     semantic_messages=semantic_messages,
                     semantic_tools=semantic_tools,
                     duration_ms=duration_ms,
+                    guardrail_findings=guardrail_findings,
                 )
             except Exception:
                 logger.warning("CompositeNotifier: on_llm_call_completed failed", exc_info=True)

--- a/packages/python/src/dendrux/notifiers/console.py
+++ b/packages/python/src/dendrux/notifiers/console.py
@@ -94,6 +94,7 @@ class ConsoleNotifier(LoopNotifier):
         semantic_messages: list[Message] | None = None,
         semantic_tools: list[ToolDef] | None = None,
         duration_ms: int | None = None,
+        guardrail_findings: dict[str, Any] | None = None,
     ) -> None:
         """Called after an LLM call completes."""
         tokens = response.usage.total_tokens if response.usage else 0

--- a/packages/python/tests/unit/test_guardrails.py
+++ b/packages/python/tests/unit/test_guardrails.py
@@ -1046,6 +1046,123 @@ class TestGuardrailSingleCall:
 
 
 # ------------------------------------------------------------------
+# Notifier protocol symmetry — guardrail_findings reaches both rails
+# ------------------------------------------------------------------
+
+
+class TestNotifierGuardrailFindingsSymmetry:
+    """The recorder receives ``guardrail_findings`` on every LLM call.
+    The notifier must receive the same kwarg so OTel/dashboard subscribers
+    can attach guardrail context to LLM events without joining through
+    the separate ``guardrail.*`` governance event stream.
+    """
+
+    async def test_singlecall_notifier_receives_guardrail_findings(self) -> None:
+        """SingleCall: incoming PII findings reach the notifier on the LLM event."""
+        from dendrux.loops.base import LoopNotifier
+
+        captured: dict[str, dict] = {}
+
+        class CapturingNotifier(LoopNotifier):
+            async def on_message_appended(self, message, iteration):
+                pass
+
+            async def on_llm_call_completed(
+                self,
+                response,
+                iteration,
+                *,
+                semantic_messages=None,
+                semantic_tools=None,
+                duration_ms=None,
+                guardrail_findings=None,
+            ):
+                captured["findings"] = guardrail_findings
+
+            async def on_tool_completed(self, tool_call, tool_result, iteration):
+                pass
+
+            async def on_governance_event(self, event_type, iteration, data, correlation_id=None):
+                pass
+
+        llm = MockLLM([_response("Classified.")])
+        agent = Agent(
+            prompt="Classify.",
+            loop=SingleCall(),
+            guardrails=[PII()],
+        )
+
+        result = await SingleCall().run(
+            agent=agent,
+            provider=llm,
+            strategy=NativeToolCalling(),
+            user_input="Classify jane@example.com",
+            notifier=CapturingNotifier(),
+        )
+
+        assert result.status == RunStatus.SUCCESS
+        # Notifier must have been called with non-None guardrail_findings
+        # (the EMAIL_ADDRESS hit from the incoming scan).
+        assert "findings" in captured, "on_llm_call_completed never fired"
+        findings = captured["findings"]
+        assert findings is not None, (
+            "Notifier received guardrail_findings=None despite an incoming "
+            "PII detection. The notifier rail is missing the kwarg the "
+            "recorder rail already gets."
+        )
+        assert "incoming" in findings
+
+    async def test_react_notifier_receives_guardrail_findings(self) -> None:
+        """ReAct: same symmetry across the iterative loop."""
+        from dendrux.loops.base import LoopNotifier
+
+        captured_findings: list[dict | None] = []
+
+        class CapturingNotifier(LoopNotifier):
+            async def on_message_appended(self, message, iteration):
+                pass
+
+            async def on_llm_call_completed(
+                self,
+                response,
+                iteration,
+                *,
+                semantic_messages=None,
+                semantic_tools=None,
+                duration_ms=None,
+                guardrail_findings=None,
+            ):
+                captured_findings.append(guardrail_findings)
+
+            async def on_tool_completed(self, tool_call, tool_result, iteration):
+                pass
+
+            async def on_governance_event(self, event_type, iteration, data, correlation_id=None):
+                pass
+
+        llm = MockLLM([_response("done")])
+        agent = Agent(
+            prompt="Be helpful.",
+            tools=[search],
+            guardrails=[PII()],
+        )
+
+        result = await ReActLoop().run(
+            agent=agent,
+            provider=llm,
+            strategy=NativeToolCalling(),
+            user_input="Lookup details for jane@example.com",
+            notifier=CapturingNotifier(),
+        )
+
+        assert result.status == RunStatus.SUCCESS
+        assert captured_findings, "on_llm_call_completed never fired"
+        # First LLM call's incoming scan finds the email — notifier must see it.
+        assert captured_findings[0] is not None
+        assert "incoming" in captured_findings[0]
+
+
+# ------------------------------------------------------------------
 # Streaming guard
 # ------------------------------------------------------------------
 


### PR DESCRIPTION
Mirrors LoopRecorder so notifiers (OTel, dashboards, webhooks) can attach guardrail context to LLM events without joining through the separate guardrail.* governance event stream.

Authored-By: Anmol Gautam <anmolgautam2428@gmail.com>
Assisted-By: Claude <noreply@anthropic.com>