### PR TITLE
release: dendrux 0.2.0a3

### DIFF
--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dendrux"
-version = "0.2.0a2"
+version = "0.2.0a3"
 description = "The runtime for agents that act in the real world."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Bumps pyproject version 0.2.0a2 -> 0.2.0a3.

Changes since 0.2.0a2:
- OpenTelemetry V1 notifier (`dendrux[otel]`, GenAI-semconv span tree: invoke_agent -> chat -> execute_tool, fail-open, governance events as span events, opt-in include_messages / include_tool_params)
- LoopNotifier lifecycle hooks (run_started/finished/failed, llm_call_started/completed/failed, tool_started/completed, message_appended, governance_event) with BaseNotifier no-op base
- ConsoleNotifier wired to lifecycle hooks; CompositeNotifier
- Fix: close lifecycle pair on approval-approve and abandoned streams
- Fix: governance event on sync rejection
- Skills: SingleCall inlines skill bodies; ReAct uses progressive use_skill
- Chat history on agent.run / agent.stream (history= kwarg)
- guardrail_findings kwarg on LoopNotifier.on_llm_call_completed
- metadata_filter on RunStore.list_runs / count_runs
- Deanonymize RunResult.answer on user-facing return path
- Aware-UTC timestamp invariant end-to-end + Postgres test matrix in CI
- Example 19: Postgres chatbot with PII + PromptInjection + Budget
- Example 20: notifier lifecycle tour
- Example 21: OTel end-to-end (7-stage tour with span-tree + invariants)
- Docs: notifier, recipes/opentelemetry, recipes/chatbot-threads

Authored-By: Anmol Gautam <anmolgautam2428@gmail.com>
Assisted-By: Claude <noreply@anthropic.com>