### PR TITLE
docs: observability stack recipe + composed example

### DIFF
--- a/docs/recipes/observability.mdx
+++ b/docs/recipes/observability.mdx
@@ -1,0 +1,244 @@
+---
+title: Observability stack
+description: Recorder + Notifier + OpenTelemetry + Dashboard + RunStore — how dendrux's four observability surfaces compose into one stack you get for free.
+---
+
+# Observability stack
+
+Dendrux ships four observability surfaces that look separate but are actually one layered stack: a durable **recorder** writes truth to your database, a fail-open **notifier** dispatches live events, the **OpenTelemetry notifier** routes those events into whatever tracing backend your app already uses, and the **dashboard** plus **RunStore** read the durable record back for visualization and APIs.
+
+You don't choose between them. They compose: same hook surface, different consumers, different failure policies, different time horizons. This page is the umbrella story — for the individual contracts see [Notifier](/docs/architecture/notifier), [Recorder](/docs/architecture/recorder), the [OpenTelemetry recipe](/docs/recipes/opentelemetry), and [Mounting the read router](/docs/recipes/mount-read-router).
+
+## The stack at a glance
+
+```text
+                     Agent loop emits events
+                  (LLM calls, tools, governance)
+                              │
+                ┌─────────────┴──────────────┐
+                │   same hook surface,        │
+                │   two seams                 │
+                ▼                              ▼
+       ┌─────────────────┐           ┌─────────────────────┐
+       │  Recorder       │           │  Notifier           │
+       │  (fail-closed)  │           │  (fail-open)        │
+       │                 │           │                     │
+       │  writes truth   │           │  ConsoleNotifier    │
+       │  to StateStore  │           │  CompositeNotifier  │
+       │  (6 DB tables)  │           │  OpenTelemetry-     │
+       │                 │           │    Notifier         │
+       │                 │           │  YourCustomNotifier │
+       └────────┬────────┘           └─────────────────────┘
+                │                              │
+                ▼                              ▼
+       ┌──────────────────┐         ┌────────────────────┐
+       │  Read consumers  │         │  Live consumers    │
+       │  ──────────────  │         │  ───────────────   │
+       │  Dashboard       │         │  Your terminal     │
+       │  RunStore        │         │  Datadog / Jaeger  │
+       │  make_read_router│         │   / Honeycomb      │
+       │  Your BI         │         │  PagerDuty / Slack │
+       └──────────────────┘         └────────────────────┘
+        "what happened"              "what's happening"
+```
+
+Each row in the picture answers a different question:
+
+| Surface | Failure policy | Consumes | Answers |
+| --- | --- | --- | --- |
+| **Recorder** | Fail-closed | The runtime loop | "What happened?" (audit truth) |
+| **Notifier** | Fail-open | The runtime loop | "What's happening?" (live wire) |
+| **OpenTelemetryNotifier** | Fail-open | The notifier surface | "What's happening across all my services?" (host's tracing stack) |
+| **Dashboard** | Reads DB | The recorder's output | "Show me run X visually" (embedded UI) |
+| **RunStore + read router** | Reads DB | The recorder's output | "Let me build my own UI / billing / exports" (programmatic + HTTP) |
+
+The split that does the work is **fail-closed vs fail-open**. The recorder cannot drop a write — if persistence fails on a critical path, the run stops. The notifier cannot kill a run — if your Slack webhook is down, the agent keeps going. Same events, two consumers, deliberately asymmetric guarantees.
+
+## The whole stack in one configuration
+
+```python
+from dendrux import Agent, tool
+from dendrux.llm.anthropic import AnthropicProvider
+from dendrux.notifiers import CompositeNotifier, ConsoleNotifier
+from dendrux.notifiers.otel import OpenTelemetryNotifier
+from dendrux.store import RunStore
+
+
+@tool
+async def lookup_weather(city: str) -> str:
+    """Return the current weather for a city."""
+    return f"Sunny, 72F in {city}"
+
+
+# 1. Recorder: configured implicitly by passing database_url.
+async with Agent(
+    provider=AnthropicProvider(model="claude-sonnet-4-6"),
+    prompt="You are a helpful assistant.",
+    tools=[lookup_weather],
+    database_url="sqlite+aiosqlite:///app.db",
+) as agent:
+
+    # 2. Notifier: compose as many as you want.
+    notifier = CompositeNotifier([
+        ConsoleNotifier(),           # live terminal output
+        OpenTelemetryNotifier(),     # emit spans onto host's TracerProvider
+        # MyAlertNotifier(),         # your own subclass — Slack, PagerDuty, custom metrics
+    ])
+
+    result = await agent.run(
+        "What's the weather in Paris?",
+        notifier=notifier,
+    )
+
+# 3. Read past — Dashboard is one way.
+#    $ dendrux dashboard --database-url sqlite+aiosqlite:///app.db
+
+# 4. Or build your own UI / BI / exports via RunStore.
+async with RunStore.from_database_url("sqlite+aiosqlite:///app.db") as store:
+    detail = await store.get_run(result.run_id)
+    events = await store.get_events(result.run_id)
+    print(f"Run finished as {detail.status} with {len(events)} events")
+```
+
+That single block configures all four observability surfaces. Nothing else is required.
+
+## What each layer captures, per run
+
+Same agent run, same events, captured four different ways:
+
+### Recorder — durable rows in your DB
+
+`PersistenceRecorder` runs automatically when `database_url` (or `state_store`) is configured. It writes into six tables:
+
+| Table | What lands here |
+| --- | --- |
+| `agent_runs` | Run anchor: status, model, tenant, parent for delegation, token + cost rollups |
+| `react_traces` | Every USER / ASSISTANT / TOOL message the loop saw |
+| `tool_calls` | Every tool invocation with params, result payload, success, duration |
+| `llm_interactions` | Per-LLM-call semantic request/response plus the raw provider payloads |
+| `token_usage` | Per-call token counts (kept for backcompat) |
+| `run_events` | Append-only state log: `run.started`, `llm.completed`, `tool.completed`, `policy.denied`, `approval.requested`, `budget.threshold`, etc. with monotonic `sequence_index` |
+
+This is the audit truth. Replays, billing rollups, SSE event streams, the embedded dashboard, and the public `RunStore` all read from these rows.
+
+### Notifier — live event dispatch
+
+The notifier sees the same events as the recorder but doesn't persist anything itself. Three built-in implementations cover most needs:
+
+- **`ConsoleNotifier`** prints a Rich-formatted live progress view to the terminal during the run.
+- **`CompositeNotifier([n1, n2, ...])`** fans events out to multiple notifiers; one failing never breaks the others.
+- **`OpenTelemetryNotifier()`** emits a [GenAI-semconv span tree](/docs/recipes/opentelemetry) onto your host application's existing `TracerProvider`.
+
+You implement your own by subclassing `BaseNotifier` and overriding only the hooks you care about — see [Notifier](/docs/architecture/notifier) for the full hook list and contract.
+
+### OpenTelemetryNotifier — your host's tracing backend
+
+`OpenTelemetryNotifier` is one specific Notifier. It produces a span tree shaped like:
+
+```text
+POST /runs                                          1.2s   ← your FastAPI / Django auto-instrumentation
+└─ invoke_agent  [my_agent]                         1.1s
+   ├─ chat  [claude-sonnet-4-6]                     340ms
+   │   gen_ai.usage.input_tokens: 1240
+   │   gen_ai.usage.output_tokens: 87
+   └─ execute_tool  [lookup_weather]                42ms
+```
+
+The spans attach to whatever span is active when `agent.run()` is called, so if your web framework has OTel auto-instrumentation, the agent's spans land inside the request trace automatically. Dendrux doesn't own the exporter — Datadog, Honeycomb, Jaeger, Grafana, or self-hosted OTLP all work because they're whatever your app already configured.
+
+Install with `pip install dendrux[otel]` and pass `OpenTelemetryNotifier()` per `agent.run()`. The full recipe is at [OpenTelemetry V1 integration](/docs/recipes/opentelemetry).
+
+### Dashboard — embedded UI reader
+
+```bash
+dendrux dashboard --database-url sqlite+aiosqlite:///app.db
+```
+
+Serves a small React UI plus a read-only HTTP API. It reads `run_events`, `agent_runs`, `react_traces`, `tool_calls`, `llm_interactions` straight from the recorder's tables and reconstructs:
+
+- A list of runs (filter by status, tenant, agent name)
+- Per-run timelines with pause segments as first-class nodes (so client-tool wait time is visible)
+- A delegation tree view for parent-child runs
+- A payload inspector with three modes (Formatted, Raw JSON, Evidence with semantic + provider payloads)
+
+The dashboard is a reference *consumer* of dendrux's public read APIs — it has no privileged access. Everything it does, your own UI can do too.
+
+### RunStore + make_read_router — programmatic + HTTP
+
+`RunStore` is the typed Python facade. `make_read_router(store)` is the same surface exposed as a mountable FastAPI router.
+
+```python
+from dendrux.store import RunStore
+
+async with RunStore.from_database_url("postgresql+asyncpg://...") as store:
+    failed_runs = await store.list_runs(status="error", limit=20)
+    for run in failed_runs:
+        events = await store.get_events(run.run_id)
+        # build your billing rollup, custom export, alerting check, etc.
+```
+
+For HTTP exposure, the [Mounting the read router recipe](/docs/recipes/mount-read-router) shows the full mount with auth, plus every endpoint's response shape.
+
+## Recommended composition
+
+For a production app, this is what we'd ship by default:
+
+```python
+notifier = CompositeNotifier([
+    ConsoleNotifier(),           # dev: see runs in the terminal
+    OpenTelemetryNotifier(),     # ops: spans in Datadog / Honeycomb / whatever
+    MyAlertNotifier(),           # business: page on-call when guardrails fire
+])
+
+agent = Agent(
+    provider=...,
+    tools=[...],
+    prompt="...",
+    database_url=os.environ["DATABASE_URL"],   # recorder writes audit truth
+    guardrails=[PII(), SecretDetection()],     # findings flow through all 3 notifiers
+    budget=Budget(max_tokens=100_000),         # threshold events flow through all 3
+)
+```
+
+Then expose the read side to your team:
+
+```python
+from dendrux.http import make_read_router
+
+app.include_router(
+    make_read_router(store=RunStore.from_database_url(os.environ["DATABASE_URL"])),
+    prefix="/api/dendrux",
+    dependencies=[Depends(authorize)],
+)
+```
+
+That gives you live terminal output, full distributed tracing in your tracing backend, on-call alerting on governance events, an audited DB record of every run, and a HTTP surface your dashboards and BI can query. With one block of configuration.
+
+## Why four surfaces (and not one)
+
+A reasonable question: if everything funnels through the same hooks, why not ship one unified observability primitive? The answer is the failure-policy split.
+
+- The **recorder is fail-closed** because losing audit data silently is worse than losing the run. If a critical write to `react_traces` or `tool_calls` fails after retries, the run stops. You can ship code that depends on the audit being complete.
+- The **notifier is fail-open** because losing a Slack notification is better than losing the run. If your OTel exporter is down or your custom alerter throws, the agent finishes and writes its result. You can ship flaky notifiers without compromising correctness.
+
+A unified primitive would force you to pick one policy. The split lets you keep the audit hard and the wire soft, which is exactly the property you want in production.
+
+## Worked end-to-end example
+
+`examples/22_observability_complete_stack.py` runs one agent with all four surfaces active simultaneously and prints a Rich report showing exactly what each layer captured. Run it after configuring `ANTHROPIC_API_KEY`:
+
+```bash
+pip install 'dendrux[anthropic,otel]'
+python examples/22_observability_complete_stack.py
+```
+
+The output shows the recorder's row counts per table, the notifier hooks that fired, the OTel span tree for the run, the custom alert notifier's counters, and the RunStore replay of the same run — all from one `agent.run()` call.
+
+## Related
+
+- [Notifier](/docs/architecture/notifier) — the extension contract and per-hook semantics
+- [Recorder](/docs/architecture/recorder) — what the recorder writes per hook and the two-tier durability policy
+- [OpenTelemetry V1 integration](/docs/recipes/opentelemetry) — span shape, semconv attributes, V1 scope
+- [Mounting the read router](/docs/recipes/mount-read-router) — HTTP surface for the read side
+- [State persistence](/docs/architecture/state-persistence) — the StateStore that the recorder writes to
+- [Governance](/docs/architecture/governance) — what governance events flow through all four surfaces

--- a/packages/python/examples/22_observability_complete_stack.py
+++ b/packages/python/examples/22_observability_complete_stack.py
@@ -1,0 +1,350 @@
+"""Example 22: Observability complete stack — recorder + notifier + OTel + RunStore in one run.
+
+Demonstrates how dendrux's four observability surfaces compose. One
+agent run, all four layers active simultaneously, then a Rich report
+showing exactly what each layer captured.
+
+The stack:
+    1. Recorder (PersistenceRecorder)  — durable audit truth in DB
+    2. Notifier: ConsoleNotifier       — live terminal output
+    3. Notifier: OpenTelemetryNotifier — host's tracing backend (here InMemorySpanExporter)
+    4. Notifier: AlertNotifier         — custom subclass counting governance events
+    5. RunStore (read facade)          — replay the recorder's output post-run
+
+See docs/recipes/observability.mdx for the umbrella story this example
+illustrates.
+
+Run:
+    ANTHROPIC_API_KEY=sk-... python examples/22_observability_complete_stack.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from collections import Counter
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from dotenv import load_dotenv
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from rich.tree import Tree
+
+from dendrux import Agent, Budget, tool
+from dendrux.guardrails import PII
+from dendrux.llm.anthropic import AnthropicProvider
+from dendrux.loops.base import BaseNotifier
+from dendrux.notifiers import CompositeNotifier, ConsoleNotifier
+from dendrux.notifiers.otel import OpenTelemetryNotifier
+from dendrux.store import RunStore
+
+if TYPE_CHECKING:
+    from dendrux.types import LLMResponse, Message, RunResult, ToolCall, ToolResult
+
+load_dotenv(Path(__file__).resolve().parents[3] / ".env")
+
+console = Console()
+
+
+# ---------------------------------------------------------------------------
+# Layer 2c — custom notifier counting governance events
+# ---------------------------------------------------------------------------
+
+
+class AlertNotifier(BaseNotifier):
+    """Custom notifier — counts governance events by type.
+
+    Real apps would do something with these (PagerDuty, Slack webhook,
+    Prometheus counters, etc.). Here we just collect them so we can
+    print a summary at the end and prove the live wire ran.
+    """
+
+    def __init__(self) -> None:
+        self.governance_events: Counter[str] = Counter()
+        self.llm_calls: int = 0
+        self.tool_calls: int = 0
+
+    async def on_governance_event(
+        self,
+        run_id: str,
+        event_type: str,
+        iteration: int,
+        data: dict[str, Any],
+        *,
+        correlation_id: str | None = None,
+    ) -> None:
+        self.governance_events[event_type] += 1
+
+    async def on_llm_call_completed(
+        self,
+        run_id: str,
+        response: LLMResponse,
+        iteration: int,
+        *,
+        semantic_messages: list[Message] | None = None,
+        semantic_tools: list[Any] | None = None,
+        duration_ms: int | None = None,
+        guardrail_findings: dict[str, Any] | None = None,
+    ) -> None:
+        self.llm_calls += 1
+
+    async def on_tool_completed(
+        self,
+        run_id: str,
+        tool_call: ToolCall,
+        tool_result: ToolResult,
+        iteration: int,
+    ) -> None:
+        self.tool_calls += 1
+
+
+# ---------------------------------------------------------------------------
+# Tools — small but trigger every observability surface
+# ---------------------------------------------------------------------------
+
+
+@tool()
+async def lookup_weather(city: str) -> str:
+    """Return the current weather for a city."""
+    return f"Sunny, 72F in {city}. Wind 8mph SW."
+
+
+@tool()
+async def lookup_customer(customer_id: str) -> dict[str, Any]:
+    """Look up a customer's profile and contact information."""
+    return {
+        "id": customer_id,
+        "name": "Jane Doe",
+        "email": "jane@example.com",
+        "phone": "+1-555-123-4567",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Reporting helpers
+# ---------------------------------------------------------------------------
+
+
+def _print_recorder_summary(detail: Any, events: list[Any], llm_calls: list[Any],
+                            tools: list[Any], traces: list[Any]) -> None:
+    table = Table(title="Layer 1: Recorder (durable audit in DB)")
+    table.add_column("Table", style="cyan")
+    table.add_column("Rows for this run", justify="right")
+    table.add_column("Notes")
+
+    table.add_row("agent_runs", "1", f"status={detail.status}, model={detail.model}")
+    table.add_row("react_traces", str(len(traces)), "user / assistant / tool messages")
+    table.add_row("tool_calls", str(len(tools)), "every tool invocation persisted")
+    table.add_row("llm_interactions", str(len(llm_calls)),
+                  "semantic + provider payloads per LLM call")
+    table.add_row("run_events", str(len(events)),
+                  "lifecycle + governance event log, monotonic sequence")
+
+    console.print(table)
+    console.print()
+
+
+def _print_notifier_summary(alert: AlertNotifier) -> None:
+    table = Table(title="Layer 2: Notifier (live event dispatch)")
+    table.add_column("Notifier", style="cyan")
+    table.add_column("What it did during the run")
+
+    table.add_row(
+        "ConsoleNotifier",
+        "Printed live progress to your terminal above this report.",
+    )
+    table.add_row(
+        "OpenTelemetryNotifier",
+        "Emitted GenAI-semconv spans (see span tree below).",
+    )
+    table.add_row(
+        "AlertNotifier (custom)",
+        f"Saw {alert.llm_calls} LLM call(s), {alert.tool_calls} tool call(s), "
+        f"{sum(alert.governance_events.values())} governance event(s).",
+    )
+
+    console.print(table)
+    if alert.governance_events:
+        gov = Table(title="Governance events the custom notifier counted")
+        gov.add_column("Event type", style="yellow")
+        gov.add_column("Count", justify="right")
+        for event_type, count in sorted(alert.governance_events.items()):
+            gov.add_row(event_type, str(count))
+        console.print(gov)
+    console.print()
+
+
+def _print_otel_spans(exporter: InMemorySpanExporter) -> None:
+    spans = sorted(exporter.get_finished_spans(), key=lambda s: s.start_time or 0)
+    if not spans:
+        console.print("[dim]No OTel spans captured.[/dim]\n")
+        return
+
+    span_by_id: dict[int, Any] = {s.context.span_id: s for s in spans}
+    children: dict[int | None, list[Any]] = {}
+    for s in spans:
+        parent_id = s.parent.span_id if s.parent else None
+        children.setdefault(parent_id, []).append(s)
+
+    def _label(span: Any) -> str:
+        dur_ms = ((span.end_time or 0) - (span.start_time or 0)) // 1_000_000
+        status = span.status.status_code.name
+        suffix = ""
+        if span.name.startswith("chat") and "gen_ai.usage.input_tokens" in span.attributes:
+            suffix = f" · tokens={span.attributes['gen_ai.usage.input_tokens']}" \
+                     f"/{span.attributes.get('gen_ai.usage.output_tokens', 0)}"
+        gov_events = [e.name for e in span.events
+                      if e.name.startswith(("policy.", "approval.", "budget.",
+                                            "guardrail.", "skill.", "mcp."))]
+        gov_suffix = f" · gov: {', '.join(gov_events)}" if gov_events else ""
+        return f"[{status}] {span.name}  {dur_ms}ms{suffix}{gov_suffix}"
+
+    tree = Tree("[bold]Layer 3: OpenTelemetryNotifier (host's TracerProvider)[/bold]")
+    roots = children.get(None, []) + [
+        s for parent_id, sibs in children.items()
+        if parent_id is not None and parent_id not in span_by_id
+        for s in sibs
+    ]
+    for root in sorted(roots, key=lambda s: s.start_time or 0):
+        _attach_children(tree.add(_label(root)), root, children)
+    console.print(tree)
+    console.print()
+
+
+def _attach_children(node: Any, span: Any, children: dict[int | None, list[Any]]) -> None:
+    for child in sorted(children.get(span.context.span_id, []), key=lambda s: s.start_time or 0):
+        _attach_children(node.add(_label_short(child)), child, children)
+
+
+def _label_short(span: Any) -> str:
+    dur_ms = ((span.end_time or 0) - (span.start_time or 0)) // 1_000_000
+    status = span.status.status_code.name
+    return f"[{status}] {span.name}  {dur_ms}ms"
+
+
+def _print_runstore_replay(detail: Any, events: list[Any], pauses: list[Any]) -> None:
+    table = Table(title="Layer 4: RunStore (programmatic read facade)")
+    table.add_column("Field", style="cyan")
+    table.add_column("Value")
+
+    table.add_row("run_id", detail.run_id)
+    table.add_row("status", detail.status)
+    table.add_row("agent_name", detail.agent_name)
+    table.add_row("model", detail.model or "")
+    table.add_row("iteration_count", str(detail.iteration_count))
+    table.add_row(
+        "tokens (in / out / cache_read)",
+        f"{detail.total_input_tokens} / "
+        f"{detail.total_output_tokens} / "
+        f"{detail.total_cache_read_tokens}",
+    )
+    table.add_row("event count", str(len(events)))
+    table.add_row("pause cycles", str(len(pauses)))
+    table.add_row("answer", (detail.answer or "")[:80] + ("..." if detail.answer and len(detail.answer) > 80 else ""))
+
+    console.print(table)
+    console.print()
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+async def main() -> None:
+    # OTel SDK setup: in production this is the host application's
+    # TracerProvider with whatever exporter the host already uses
+    # (OTLP -> Datadog / Honeycomb / Jaeger / Grafana / etc.). Here we
+    # use InMemorySpanExporter so the demo is self-contained.
+    provider = TracerProvider()
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+
+    # One temp DB so the recorder has somewhere to write and RunStore
+    # can read back from the same place.
+    db_dir = Path(tempfile.mkdtemp(prefix="dendrux_observability_"))
+    db_url = f"sqlite+aiosqlite:///{db_dir}/observability.db"
+
+    alert_notifier = AlertNotifier()
+
+    # ---- One agent run with all four observability surfaces active ----
+    console.print(
+        Panel(
+            "[bold]Running one agent with the complete observability stack[/bold]\n\n"
+            "Layer 1: PersistenceRecorder (configured by database_url)\n"
+            "Layer 2: CompositeNotifier composing 3 notifiers\n"
+            "Layer 3: OpenTelemetryNotifier emits GenAI semconv spans\n"
+            "Layer 4: RunStore reads back the recorder's output after the run",
+            title="Observability Stack",
+        )
+    )
+
+    async with Agent(
+        provider=AnthropicProvider(model="claude-sonnet-4-6"),
+        prompt=(
+            "You are a helpful assistant. When asked for weather, use the lookup_weather tool. "
+            "When asked about customers, use lookup_customer."
+        ),
+        tools=[lookup_weather, lookup_customer],
+        database_url=db_url,
+        guardrails=[PII()],
+        budget=Budget(max_tokens=20_000, warn_at=(0.5, 0.75, 0.9)),
+    ) as agent:
+        notifier = CompositeNotifier([
+            ConsoleNotifier(),
+            OpenTelemetryNotifier(),
+            alert_notifier,
+        ])
+
+        result = await agent.run(
+            "Look up customer C-7782, then check the weather in their city — assume Paris.",
+            notifier=notifier,
+        )
+
+    console.print()
+    console.print(Panel(f"[bold]Run complete: {result.status.value}[/bold]\n\n{result.answer or ''}",
+                        title="Result"))
+    console.print()
+
+    # ---- Read back via RunStore — same source as the dashboard would use ----
+    async with RunStore.from_database_url(db_url) as store:
+        detail = await store.get_run(result.run_id)
+        assert detail is not None
+        events = await store.get_events(result.run_id)
+        llm_calls = await store.get_llm_calls(result.run_id)
+        tool_invocations = await store.get_tool_invocations(result.run_id)
+        traces = await store.get_traces(result.run_id)
+        pauses = await store.get_pauses(result.run_id)
+
+    # ---- Report ----
+    console.print(Panel("[bold]What each observability layer captured[/bold]",
+                        title="Stack report"))
+    console.print()
+    _print_recorder_summary(detail, events, llm_calls, tool_invocations, traces)
+    _print_notifier_summary(alert_notifier)
+    _print_otel_spans(exporter)
+    _print_runstore_replay(detail, events, pauses)
+
+    console.print(
+        Panel(
+            "All four surfaces saw the same agent run.\n\n"
+            "Same hook events. Different consumers, different time horizons, different failure policies:\n"
+            "  • Recorder: durable, fail-closed, queryable forever via RunStore\n"
+            "  • Notifier (live): fail-open, dispatched as the run unfolds\n"
+            "  • OTel: spans plug into the host's existing observability stack\n"
+            "  • Custom: any BaseNotifier subclass — Slack / PagerDuty / Prometheus / etc.\n\n"
+            "You configured all four with one Agent + one notifier= kwarg.",
+            title="Why the stack composes",
+        )
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
- docs/recipes/observability.mdx — umbrella page tying Recorder, Notifier, OpenTelemetry, Dashboard, RunStore into one layered story with the fail-closed vs fail-open rationale
- examples/22_observability_complete_stack.py — one agent run with all four surfaces active; prints a Rich report showing what each layer captured

Authored-By: Anmol Gautam <anmolgautam2428@gmail.com>
Assisted-By: Claude <noreply@anthropic.com>