### PR TITLE
fix: drop classDef styling from observability Mermaid block

### DIFF
--- a/docs/recipes/observability.mdx
+++ b/docs/recipes/observability.mdx
@@ -24,16 +24,6 @@ You don't choose between them. They compose: same hook surface, different consum
     Recorder --> Store
     Store --> Read
     Notifier --> Live
-
-    classDef src fill:#0d1018,stroke:#3a4258,color:#e8e8ee
-    classDef truth fill:#15192a,stroke:#4a90e2,color:#e8e8ee
-    classDef live fill:#15192a,stroke:#e2b04a,color:#e8e8ee
-    classDef store fill:#0d1018,stroke:#6b7280,color:#e8e8ee
-
-    class Loop src
-    class Recorder,Read truth
-    class Notifier,Live live
-    class Store store
 `} />
 
 Each surface answers a different question:


### PR DESCRIPTION
classDef rules trigger a Mermaid v11 internal "Cannot read properties of undefined (reading 'replace')" error during render. Dropping them lets the diagram render with the default dark theme; we can revisit custom colors once Mermaid v11 stabilizes that path.

Authored-By: Anmol Gautam <anmolgautam2428@gmail.com>
Assisted-By: Claude <noreply@anthropic.com>