### PR TITLE
feat: fail fast with DB setup guidance when schema is missing

### DIFF
--- a/docs/architecture/state-persistence.mdx
+++ b/docs/architecture/state-persistence.mdx
@@ -239,6 +239,21 @@ Dendrux uses **SQLAlchemy 2.x async**. Anything async-SQLAlchemy supports works:
 
 The schema doesn't use any SQLite-specific or Postgres-specific features. Switching backends is a connection string change.
 
+## Setting up the schema
+
+SQLite creates its tables automatically on first use, so there is nothing to run. Every other backend needs the tables created once before the first run. Dendrux ships an Alembic migration set and a small CLI for exactly this:
+
+```bash
+pip install "dendrux[postgres]"          # asyncpg driver (alembic is already bundled)
+export DENDRUX_DATABASE_URL=postgresql+asyncpg://user:pass@host:5432/dbname
+dendrux db migrate                       # create / upgrade the six tables
+dendrux db status                        # show the current migration revision
+```
+
+`DENDRUX_DATABASE_URL` is the one knob the CLI reads. It never accepts the URL as a flag, so credentials stay out of your shell history and process list. The same variable is also the fallback your app uses when you build an `Agent` without an explicit `database_url=`, so setting it once covers both migration and runtime.
+
+If the tables are missing when a run starts, dendrux raises `SchemaNotInitializedError` carrying these exact commands, rather than letting a raw "relation does not exist" error surface mid-run.
+
 ## What's next
 
 - [Event ordering](/docs/architecture/event-ordering): why `sequence_index` exists and how SSE resume uses it.

--- a/packages/python/examples/19_chatbot_postgres.py
+++ b/packages/python/examples/19_chatbot_postgres.py
@@ -1,4 +1,13 @@
-"""19 — CLI chatbot with Postgres + governance (PII, PromptInjection, Budget)."""
+"""19 — CLI chatbot with Postgres + governance (PII, PromptInjection, Budget).
+
+First-time setup: Postgres tables are not auto-created. Create them once before
+running this example, otherwise the first turn raises SchemaNotInitializedError:
+
+    export DENDRUX_DATABASE_URL=postgresql+asyncpg://postgres:root@localhost:5432/dendrux
+    dendrux db migrate
+
+SQLite needs none of this (it auto-creates). See docs: architecture/state-persistence.
+"""
 
 from __future__ import annotations
 

--- a/packages/python/src/dendrux/__init__.py
+++ b/packages/python/src/dendrux/__init__.py
@@ -17,6 +17,7 @@ from dendrux.errors import (
     RunAlreadyTerminalError,
     RunNotFoundError,
     RunNotPausedError,
+    SchemaNotInitializedError,
 )
 from dendrux.loops.single import SingleCall
 from dendrux.runtime.context import DelegationDepthExceededError
@@ -47,6 +48,7 @@ __all__ = [
     "RunAlreadyTerminalError",
     "RunNotFoundError",
     "RunNotPausedError",
+    "SchemaNotInitializedError",
     "SingleCall",
     "StructuredOutputValidationError",
     "run",

--- a/packages/python/src/dendrux/agent.py
+++ b/packages/python/src/dendrux/agent.py
@@ -89,6 +89,30 @@ def _record_to_run_result(record: Any) -> RunResult:
     )
 
 
+async def _verify_schema_initialized(engine: AsyncEngine, url: str) -> None:
+    """Fail fast with setup guidance if a non-SQLite database has no tables.
+
+    SQLite auto-creates its schema in ``_create_private_engine`` / ``get_engine``,
+    so the check is skipped there. For Postgres and other backends the schema
+    must be migrated first; a missing ``agent_runs`` table means the dev never
+    ran ``dendrux db migrate``, so raise a clear, actionable error instead of
+    letting a raw "relation does not exist" surface mid-run.
+    """
+    if url.startswith("sqlite"):
+        return
+
+    from sqlalchemy import inspect as _sa_inspect
+
+    from dendrux.errors import SchemaNotInitializedError
+
+    async with engine.connect() as conn:
+        present = await conn.run_sync(
+            lambda sync_conn: _sa_inspect(sync_conn).has_table("agent_runs")
+        )
+    if not present:
+        raise SchemaNotInitializedError()
+
+
 class Agent:
     """Dendrux agent — definition and runtime facade.
 
@@ -603,6 +627,7 @@ class Agent:
         if self._database_url is not None:
             engine = await self._create_private_engine(self._database_url)
             self._private_engine = engine
+            await _verify_schema_initialized(engine, self._database_url)
             self._lazy_store = SQLAlchemyStateStore(engine)
             return self._lazy_store
 
@@ -611,6 +636,7 @@ class Agent:
             from dendrux.db.session import get_engine
 
             engine = await get_engine(env_url)
+            await _verify_schema_initialized(engine, env_url)
             self._lazy_store = SQLAlchemyStateStore(engine)
             return self._lazy_store
 

--- a/packages/python/src/dendrux/errors.py
+++ b/packages/python/src/dendrux/errors.py
@@ -15,6 +15,7 @@ Suggested HTTP mappings:
     RunAlreadyTerminalError     -> 409
     InvalidToolResultError      -> 400
     PersistenceNotConfiguredError -> 500
+    SchemaNotInitializedError   -> 500
 """
 
 from __future__ import annotations
@@ -130,6 +131,26 @@ class PersistenceNotConfiguredError(RuntimeError):
         )
 
 
+class SchemaNotInitializedError(RuntimeError):
+    """Raised when the configured database has no Dendrux tables yet.
+
+    SQLite auto-creates its schema on first use, so this never fires
+    there. Postgres (and other backends) require an explicit migration
+    step before the first run. The message points at the CLI commands
+    that set the schema up.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            "Dendrux tables not found in the configured database. "
+            "Run migrations before the first run:\n\n"
+            "    export DENDRUX_DATABASE_URL=<your-database-url>\n"
+            "    dendrux db migrate\n\n"
+            "SQLite auto-creates its schema; Postgres and other backends "
+            "require this step. Check status with 'dendrux db status'."
+        )
+
+
 __all__ = [
     "InvalidToolResultError",
     "PauseStatusMismatchError",
@@ -138,4 +159,5 @@ __all__ = [
     "RunAlreadyTerminalError",
     "RunNotFoundError",
     "RunNotPausedError",
+    "SchemaNotInitializedError",
 ]

--- a/packages/python/tests/unit/test_agent.py
+++ b/packages/python/tests/unit/test_agent.py
@@ -352,6 +352,72 @@ class TestAgentPrivateEngine:
 
 
 # ------------------------------------------------------------------
+# Persistence: schema verification (first-run setup DX)
+# ------------------------------------------------------------------
+
+
+class TestSchemaVerification:
+    """Non-SQLite backends must be migrated before first use; fail fast if not.
+
+    The url argument only gates the SQLite skip, so a file-backed SQLite
+    engine paired with a postgres-looking url exercises the real
+    inspector path deterministically without a live Postgres.
+    """
+
+    async def test_raises_when_tables_missing(self):
+        from sqlalchemy.ext.asyncio import create_async_engine
+
+        from dendrux.agent import _verify_schema_initialized
+        from dendrux.errors import SchemaNotInitializedError
+
+        with tempfile.TemporaryDirectory() as tmp:
+            url = f"sqlite+aiosqlite:///{Path(tmp) / 'empty.db'}"
+            engine = create_async_engine(url)
+            try:
+                with pytest.raises(SchemaNotInitializedError, match="dendrux db migrate"):
+                    await _verify_schema_initialized(engine, "postgresql+asyncpg://nope")
+            finally:
+                await engine.dispose()
+
+    async def test_passes_when_tables_present(self):
+        from sqlalchemy.ext.asyncio import create_async_engine
+
+        from dendrux.agent import _verify_schema_initialized
+        from dendrux.db.models import Base
+
+        with tempfile.TemporaryDirectory() as tmp:
+            url = f"sqlite+aiosqlite:///{Path(tmp) / 'ready.db'}"
+            engine = create_async_engine(url)
+            try:
+                async with engine.begin() as conn:
+                    await conn.run_sync(Base.metadata.create_all)
+                # postgres-looking url forces the inspector path, not the skip
+                await _verify_schema_initialized(engine, "postgresql+asyncpg://nope")
+            finally:
+                await engine.dispose()
+
+    async def test_skips_sqlite_even_without_tables(self):
+        from sqlalchemy.ext.asyncio import create_async_engine
+
+        from dendrux.agent import _verify_schema_initialized
+
+        with tempfile.TemporaryDirectory() as tmp:
+            url = f"sqlite+aiosqlite:///{Path(tmp) / 'empty.db'}"
+            engine = create_async_engine(url)
+            try:
+                # SQLite auto-creates elsewhere, so the check is a no-op here
+                await _verify_schema_initialized(engine, url)
+            finally:
+                await engine.dispose()
+
+    def test_error_is_exported(self):
+        from dendrux import SchemaNotInitializedError as Exported
+        from dendrux.errors import SchemaNotInitializedError
+
+        assert Exported is SchemaNotInitializedError
+
+
+# ------------------------------------------------------------------
 # Validation
 # ------------------------------------------------------------------
 


### PR DESCRIPTION
- add SchemaNotInitializedError, raised on first run when a non-SQLite DB has no tables
- check runs in _resolve_state_store for both private-engine and env-var paths
- message points at `dendrux db migrate`; SQLite still auto-creates and is skipped
- docs: "Setting up the schema" section + example 19 migrate note

Authored-By: Anmol Gautam <anmolgautam2428@gmail.com>
Assisted-By: Claude <noreply@anthropic.com>