### PR TITLE
fix: record actual per-call model + chat-endpoint recipe

### DIFF
--- a/docs/recipes/web-endpoint.mdx
+++ b/docs/recipes/web-endpoint.mdx
@@ -1,0 +1,112 @@
+---
+title: dendrux in a web or chat endpoint
+description: How to run dendrux inside a stateless HTTP server — build the Agent per request, share the expensive resources, switch model per turn, and resume long runs across processes.
+---
+
+# dendrux in a web or chat endpoint
+
+dendrux is built to run inside *your* server. This recipe is the architecture for doing that well: what to build per request, what to share, how to switch model per turn, and how a single long-running task survives across requests.
+
+## The one idea
+
+**The Agent is a disposable executor. The run is the durable thing.**
+
+- dendrux persists run state (runs, events, traces, tool calls, LLM calls, pauses) to your database.
+- It does **not** persist the Agent object or the conversation history. Your app owns the conversation.
+
+Because state lives in the DB, you can build a fresh Agent on each request — even on a different machine — and resume any run by ID. Constructing an Agent does no I/O, so this is cheap. The [Quickstart](/docs/quickstart) shows the proof: a run started in one process is resumed in another.
+
+## Build per request, share the expensive parts
+
+Building the `Agent` object is essentially free. The cost is in the resources it connects to. Build those **once per worker** and reuse them:
+
+| Resource | Cost if rebuilt per request | What to do |
+| --- | --- | --- |
+| DB engine | A new connection pool every request | Share one: set `DENDRUX_DATABASE_URL` or inject a `state_store`. |
+| MCP server | Re-spawns a subprocess / reconnects + re-lists tools | Pool the `MCPServer` objects; reuse them. |
+| Provider client | Loses connection keep-alive | Optional: pool by `(vendor, model)`. |
+
+```python
+# ---- once per worker (startup) ----
+from dendrux.db.session import get_engine
+from dendrux.runtime.state import SQLAlchemyStateStore
+
+engine = await get_engine(os.environ["DENDRUX_DATABASE_URL"])  # shared singleton
+STORE  = SQLAlchemyStateStore(engine)
+MCP_POOL  = {}   # name -> MCPServer (sessions stay open)
+PROVIDERS = {}   # (vendor, model) -> provider
+
+# ---- per request ----
+@app.post("/chat")
+async def chat(req):
+    agent = Agent(
+        provider=PROVIDERS[(req.vendor, req.model)],
+        prompt=req.system_prompt,
+        tools=[TOOLS[t] for t in req.enabled_tools],          # current selection
+        tool_sources=[MCP_POOL[m] for m in req.enabled_mcps], # current selection
+        state_store=STORE,                                    # shared engine
+    )
+    result = await agent.run(
+        req.text,
+        history=req.transcript,                               # your app owns this
+        metadata={"thread_id": req.thread_id},
+    )
+    return {"answer": result.answer}
+```
+
+### Do not call `close()` per request when you pool
+
+`agent.close()` (and `async with Agent(...)`) closes the provider and the MCP sources. That is what you want for a one-off script, but it is **wrong** when those are shared: it tears down the pool the next request needs.
+
+The Agent has no destructor, so simply **not** calling `close()` leaves everything open. In a pooled server: let the lightweight Agent be garbage-collected, and close the pooled `MCPServer`/provider objects yourself at worker shutdown.
+
+```python
+@app.on_event("shutdown")
+async def shutdown():
+    for mcp in MCP_POOL.values():
+        await mcp.close()
+    for provider in PROVIDERS.values():
+        await provider.close()
+```
+
+## Switching model or vendor per turn
+
+For a "pick your model per message" chatbot:
+
+- **Model (same vendor):** pass it to `run()`. No new Agent needed.
+
+  ```python
+  await agent.run(req.text, history=req.transcript, model="claude-opus-4-1")
+  ```
+
+  The model actually used is recorded per call, so [`RunStore.get_llm_calls`](/docs/reference/run-store) reflects the real model for billing and observability.
+
+- **Vendor, prompt, or tool set:** rebuild the Agent with the new `provider` / `prompt` / `tools`. Construction is cheap, and rebuilding is the clean way to reflect a capability set the user changed mid-chat.
+
+## New turn vs. continuing a long run
+
+A long-running task usually **pauses and resumes** rather than finishing in one call. Use the right entry point:
+
+- **New turn** → `agent.run(...)` starts a new run.
+- **Continue a paused run** → `agent.submit_tool_results()` / `submit_input()` / `submit_approval()` / `resume()` on the existing `run_id`.
+
+Both work with a freshly built Agent, possibly in a different process. One thing to know: on resume, dendrux replays the conversation from the DB but takes the **provider, model, prompt, and tools from the Agent you resume with** — not from a saved snapshot. So keep the config consistent across the resume. The clean way is to stash a config key when you start the run and read it back:
+
+```python
+# start
+await agent.run(text, metadata={"thread_id": tid, "config_id": cfg_id})
+
+# later — resume with the SAME config the run started with
+run = await store.get_run(run_id)
+agent = build_agent(load_config(run.meta["config_id"]))
+await agent.submit_tool_results(run_id, results)
+```
+
+New *turns* can use the user's latest model/tool selection; an *in-flight* run should be resumed with its own config (especially if it paused waiting on a client tool the user may have since toggled off).
+
+## Where this fits
+
+- [Quickstart](/docs/quickstart): the pause-in-one-process, resume-in-another proof.
+- [Chatbot threads](/docs/recipes/chatbot-threads): grouping turns into a conversation with `metadata`.
+- [Your app DB vs the Dendrux DB](/docs/recipes/app-database-boundary): who stores what.
+- [Pause and resume](/docs/architecture/pause-resume): the resume entry points in detail.

--- a/packages/python/examples/22_observability_complete_stack.py
+++ b/packages/python/examples/22_observability_complete_stack.py
@@ -45,7 +45,7 @@ from dendrux.notifiers.otel import OpenTelemetryNotifier
 from dendrux.store import RunStore
 
 if TYPE_CHECKING:
-    from dendrux.types import LLMResponse, Message, RunResult, ToolCall, ToolResult
+    from dendrux.types import LLMResponse, Message, ToolCall, ToolResult
 
 load_dotenv(Path(__file__).resolve().parents[3] / ".env")
 
@@ -131,8 +131,9 @@ async def lookup_customer(customer_id: str) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def _print_recorder_summary(detail: Any, events: list[Any], llm_calls: list[Any],
-                            tools: list[Any], traces: list[Any]) -> None:
+def _print_recorder_summary(
+    detail: Any, events: list[Any], llm_calls: list[Any], tools: list[Any], traces: list[Any]
+) -> None:
     table = Table(title="Layer 1: Recorder (durable audit in DB)")
     table.add_column("Table", style="cyan")
     table.add_column("Rows for this run", justify="right")
@@ -141,10 +142,12 @@ def _print_recorder_summary(detail: Any, events: list[Any], llm_calls: list[Any]
     table.add_row("agent_runs", "1", f"status={detail.status}, model={detail.model}")
     table.add_row("react_traces", str(len(traces)), "user / assistant / tool messages")
     table.add_row("tool_calls", str(len(tools)), "every tool invocation persisted")
-    table.add_row("llm_interactions", str(len(llm_calls)),
-                  "semantic + provider payloads per LLM call")
-    table.add_row("run_events", str(len(events)),
-                  "lifecycle + governance event log, monotonic sequence")
+    table.add_row(
+        "llm_interactions", str(len(llm_calls)), "semantic + provider payloads per LLM call"
+    )
+    table.add_row(
+        "run_events", str(len(events)), "lifecycle + governance event log, monotonic sequence"
+    )
 
     console.print(table)
     console.print()
@@ -197,17 +200,24 @@ def _print_otel_spans(exporter: InMemorySpanExporter) -> None:
         status = span.status.status_code.name
         suffix = ""
         if span.name.startswith("chat") and "gen_ai.usage.input_tokens" in span.attributes:
-            suffix = f" · tokens={span.attributes['gen_ai.usage.input_tokens']}" \
-                     f"/{span.attributes.get('gen_ai.usage.output_tokens', 0)}"
-        gov_events = [e.name for e in span.events
-                      if e.name.startswith(("policy.", "approval.", "budget.",
-                                            "guardrail.", "skill.", "mcp."))]
+            suffix = (
+                f" · tokens={span.attributes['gen_ai.usage.input_tokens']}"
+                f"/{span.attributes.get('gen_ai.usage.output_tokens', 0)}"
+            )
+        gov_events = [
+            e.name
+            for e in span.events
+            if e.name.startswith(
+                ("policy.", "approval.", "budget.", "guardrail.", "skill.", "mcp.")
+            )
+        ]
         gov_suffix = f" · gov: {', '.join(gov_events)}" if gov_events else ""
         return f"[{status}] {span.name}  {dur_ms}ms{suffix}{gov_suffix}"
 
     tree = Tree("[bold]Layer 3: OpenTelemetryNotifier (host's TracerProvider)[/bold]")
     roots = children.get(None, []) + [
-        s for parent_id, sibs in children.items()
+        s
+        for parent_id, sibs in children.items()
         if parent_id is not None and parent_id not in span_by_id
         for s in sibs
     ]
@@ -246,7 +256,9 @@ def _print_runstore_replay(detail: Any, events: list[Any], pauses: list[Any]) ->
     )
     table.add_row("event count", str(len(events)))
     table.add_row("pause cycles", str(len(pauses)))
-    table.add_row("answer", (detail.answer or "")[:80] + ("..." if detail.answer and len(detail.answer) > 80 else ""))
+    _answer = detail.answer or ""
+    _preview = _answer[:80] + ("..." if len(_answer) > 80 else "")
+    table.add_row("answer", _preview)
 
     console.print(table)
     console.print()
@@ -297,11 +309,13 @@ async def main() -> None:
         guardrails=[PII()],
         budget=Budget(max_tokens=20_000, warn_at=(0.5, 0.75, 0.9)),
     ) as agent:
-        notifier = CompositeNotifier([
-            ConsoleNotifier(),
-            OpenTelemetryNotifier(),
-            alert_notifier,
-        ])
+        notifier = CompositeNotifier(
+            [
+                ConsoleNotifier(),
+                OpenTelemetryNotifier(),
+                alert_notifier,
+            ]
+        )
 
         result = await agent.run(
             "Look up customer C-7782, then check the weather in their city — assume Paris.",
@@ -309,8 +323,12 @@ async def main() -> None:
         )
 
     console.print()
-    console.print(Panel(f"[bold]Run complete: {result.status.value}[/bold]\n\n{result.answer or ''}",
-                        title="Result"))
+    console.print(
+        Panel(
+            f"[bold]Run complete: {result.status.value}[/bold]\n\n{result.answer or ''}",
+            title="Result",
+        )
+    )
     console.print()
 
     # ---- Read back via RunStore — same source as the dashboard would use ----
@@ -324,8 +342,9 @@ async def main() -> None:
         pauses = await store.get_pauses(result.run_id)
 
     # ---- Report ----
-    console.print(Panel("[bold]What each observability layer captured[/bold]",
-                        title="Stack report"))
+    console.print(
+        Panel("[bold]What each observability layer captured[/bold]", title="Stack report")
+    )
     console.print()
     _print_recorder_summary(detail, events, llm_calls, tool_invocations, traces)
     _print_notifier_summary(alert_notifier)
@@ -335,7 +354,8 @@ async def main() -> None:
     console.print(
         Panel(
             "All four surfaces saw the same agent run.\n\n"
-            "Same hook events. Different consumers, different time horizons, different failure policies:\n"
+            "Same hook events. Different consumers, different time horizons, "
+            "different failure policies:\n"
             "  • Recorder: durable, fail-closed, queryable forever via RunStore\n"
             "  • Notifier (live): fail-open, dispatched as the run unfolds\n"
             "  • OTel: spans plug into the host's existing observability stack\n"

--- a/packages/python/src/dendrux/agent.py
+++ b/packages/python/src/dendrux/agent.py
@@ -753,7 +753,12 @@ class Agent:
                 is raised. Requires persistence (database_url, state_store, or
                 DENDRUX_DATABASE_URL). The hash includes ``history`` — same input
                 with different history is treated as a different request.
-            **kwargs: Forwarded to the LLM provider (temperature, max_tokens, etc.).
+            **kwargs: Forwarded to the LLM provider. Pass ``model=`` to override
+                the provider's configured model for this call only (e.g.
+                ``model="claude-opus-4-1"``) — useful for per-turn model selection
+                in a chatbot. Also accepts ``temperature``, ``max_tokens``, and
+                other provider sampling params. The model actually used is recorded
+                per LLM call (see ``RunStore.get_llm_calls``).
 
         Returns:
             RunResult with status, answer, steps, and usage stats.
@@ -1330,7 +1335,12 @@ class Agent:
             notifier: Optional notifier for lifecycle events.
             max_delegation_depth: Maximum allowed delegation depth for the run
                 tree. Default 10. None means unbounded.
-            **kwargs: Forwarded to the LLM provider (temperature, max_tokens, etc.).
+            **kwargs: Forwarded to the LLM provider. Pass ``model=`` to override
+                the provider's configured model for this call only (e.g.
+                ``model="claude-opus-4-1"``) — useful for per-turn model selection
+                in a chatbot. Also accepts ``temperature``, ``max_tokens``, and
+                other provider sampling params. The model actually used is recorded
+                per LLM call (see ``RunStore.get_llm_calls``).
 
         Returns:
             RunStream — async iterable of RunEvent objects.

--- a/packages/python/src/dendrux/llm/anthropic.py
+++ b/packages/python/src/dendrux/llm/anthropic.py
@@ -283,6 +283,7 @@ class AnthropicProvider(LLMProvider):
 
         # Attach adapter-boundary payloads for evidence layer
         llm_response.provider_request = captured_request
+        llm_response.model = captured_request["model"]
         llm_response.provider_response = response.model_dump()
 
         return llm_response
@@ -400,6 +401,7 @@ class AnthropicProvider(LLMProvider):
             usage=usage,
         )
         llm_response.provider_request = captured_request
+        llm_response.model = captured_request["model"]
         llm_response.provider_response = final_message.model_dump()
 
         yield StreamEvent(type=StreamEventType.DONE, raw=llm_response)

--- a/packages/python/src/dendrux/llm/mock.py
+++ b/packages/python/src/dendrux/llm/mock.py
@@ -72,6 +72,8 @@ class MockLLM(LLMProvider):
 
         response = self._responses[self._call_count]
         self._call_count += 1
+        # Mirror real providers: honor a per-call ``model=`` override.
+        response.model = kwargs.get("model") or self._model
         return response
 
     @property

--- a/packages/python/src/dendrux/llm/openai.py
+++ b/packages/python/src/dendrux/llm/openai.py
@@ -355,6 +355,7 @@ class OpenAIProvider(LLMProvider):
 
         # Attach adapter-boundary payloads for evidence layer
         llm_response.provider_request = captured_request
+        llm_response.model = captured_request["model"]
         llm_response.provider_response = response.model_dump()
 
         return llm_response
@@ -527,6 +528,7 @@ class OpenAIProvider(LLMProvider):
             usage=usage,
         )
         llm_response.provider_request = captured_request
+        llm_response.model = captured_request["model"]
         llm_response.provider_response = {
             "object": "chat.completion.chunked",
             "finish_reason": finish_reason,

--- a/packages/python/src/dendrux/llm/openai_responses.py
+++ b/packages/python/src/dendrux/llm/openai_responses.py
@@ -352,6 +352,7 @@ class OpenAIResponsesProvider(LLMProvider):
 
         # Attach adapter-boundary payloads for evidence layer
         llm_response.provider_request = captured_request
+        llm_response.model = captured_request["model"]
         llm_response.provider_response = response.model_dump()
 
         return llm_response
@@ -499,6 +500,7 @@ class OpenAIResponsesProvider(LLMProvider):
             usage=usage,
         )
         llm_response.provider_request = captured_request
+        llm_response.model = captured_request["model"]
         if _completed_response is not None and hasattr(_completed_response, "model_dump"):
             llm_response.provider_response = _completed_response.model_dump()
 

--- a/packages/python/src/dendrux/runtime/persistence.py
+++ b/packages/python/src/dendrux/runtime/persistence.py
@@ -207,7 +207,7 @@ class PersistenceRecorder(BaseRecorder):
                 self._run_id,
                 iteration_index=iteration,
                 usage=response.usage,
-                model=self._model,
+                model=response.model or self._model,
                 provider=self._provider_name,
                 duration_ms=duration_ms,
                 semantic_request=semantic_request,
@@ -230,7 +230,7 @@ class PersistenceRecorder(BaseRecorder):
                 self._run_id,
                 iteration_index=iteration,
                 usage=response.usage,
-                model=self._model,
+                model=response.model or self._model,
                 provider=self._provider_name,
             )
         except Exception:
@@ -251,7 +251,7 @@ class PersistenceRecorder(BaseRecorder):
                 "cache_read_input_tokens": response.usage.cache_read_input_tokens,
                 "cache_creation_input_tokens": response.usage.cache_creation_input_tokens,
                 "cost_usd": response.usage.cost_usd,
-                "model": self._model,
+                "model": response.model or self._model,
                 "has_tool_calls": bool(response.tool_calls),
             },
         )

--- a/packages/python/src/dendrux/types.py
+++ b/packages/python/src/dendrux/types.py
@@ -256,6 +256,9 @@ class LLMResponse:
     # provider_response: the raw vendor response dict (e.g. response.model_dump()).
     provider_request: dict[str, Any] | None = None
     provider_response: dict[str, Any] | None = None
+    # The model actually used for this call. Honors a per-call ``model=`` override;
+    # falls back to the provider's configured model when a provider leaves it unset.
+    model: str | None = None
 
 
 @dataclass(frozen=True)

--- a/packages/python/tests/unit/test_llm_interactions.py
+++ b/packages/python/tests/unit/test_llm_interactions.py
@@ -261,3 +261,41 @@ class TestResumeCoreCAsBugFix:
         # The fix: error_won check before _emit_event in the except block
         assert "error_won" in source, "_resume_core should use error_won CAS check"
         assert "if error_won:" in source, "_resume_core should guard emit with 'if error_won:'"
+
+
+# ------------------------------------------------------------------
+# Recorded model reflects the actual per-call model (per-turn override)
+# ------------------------------------------------------------------
+
+
+class TestRecorderRecordsActualModel:
+    """The recorded model must reflect the model actually used for the call
+    (honoring a per-call ``model=`` override), not just the recorder default.
+    Falls back to the default when a provider leaves ``LLMResponse.model``
+    unset, so existing providers/paths are unaffected.
+    """
+
+    async def test_uses_response_model_when_set(self) -> None:
+        store = MockStateStore()
+        obs = PersistenceRecorder(
+            store, "run_1", model="claude-haiku-4-5", provider_name="Anthropic"
+        )
+
+        response = LLMResponse(text="hi", usage=UsageStats(), model="claude-opus-4-1")
+        await obs.on_llm_call_completed("run_1", response, iteration=1)
+
+        assert store.llm_interactions[0]["model"] == "claude-opus-4-1"
+        assert store.usages[0]["model"] == "claude-opus-4-1"
+        assert store._events["run_1"][0]["data"]["model"] == "claude-opus-4-1"
+
+    async def test_falls_back_to_default_when_unset(self) -> None:
+        store = MockStateStore()
+        obs = PersistenceRecorder(
+            store, "run_1", model="claude-haiku-4-5", provider_name="Anthropic"
+        )
+
+        response = LLMResponse(text="hi", usage=UsageStats())  # model unset
+        await obs.on_llm_call_completed("run_1", response, iteration=1)
+
+        assert store.llm_interactions[0]["model"] == "claude-haiku-4-5"
+        assert store.usages[0]["model"] == "claude-haiku-4-5"


### PR DESCRIPTION
## What & why

A team building a chatbot on dendrux flagged two things; this addresses them (and unbreaks CI).

### 1. Bug: per-turn `model=` was not recorded correctly
`agent.run(text, model="claude-sonnet-4-6")` already overrides the model per call (kwargs flow to the provider). But the **recorded** model showed the agent's default, not the model actually used — the real model only survived in the raw `provider_response`. This corrupts billing/observability-by-model.

**Fix:** `LLMResponse` carries the effective `model`; the recorder writes it across `llm_interactions`, `token_usage`, and the `llm.completed` event. Falls back to the provider default when unset, so existing providers/paths are unchanged.

Verified live (one Agent, three turns):
```
default          recorded=claude-haiku-4-5
run(model=sonnet) recorded=claude-sonnet-4-6   (was: claude-haiku-4-5)
run(model=opus)   recorded=claude-opus-4-1     (was: claude-haiku-4-5)
```

### 2. Docs
- Document `model=` as a first-class per-turn override on `run()`/`stream()`.
- New recipe **"dendrux in a web or chat endpoint"**: build the Agent per request, share engine/MCP/provider at process scope, don't `close()` per request when pooling, switch model per turn, resume long runs with consistent config.

### 3. Chore (required for green CI)
`examples/22_observability_complete_stack.py` fails `ruff check`/`ruff format` under ruff 0.15 (`ruff>=0.8` floats, so CI uses 0.15) — **main is currently red**. Fixed the F401 + 3×E501 + reformat.

## Tests
- New `TestRecorderRecordsActualModel` (override recorded; falls back to default).
- Full suite: 1484 passed, 245 skipped, coverage 90.48%. ruff + mypy clean.

## Deliberately out of scope (follow-up)
The `close()`-ownership change (don't auto-close caller-passed provider/MCP, mirroring the engine's rule). The recipe already unblocks pooling today by not calling `close()`; the semantics change is behavior-affecting and will be a separate PR with a rollout decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)