### PR TITLE
feat: provider recipe string (provider="vendor:model")

### DIFF
--- a/docs/recipes/web-endpoint.mdx
+++ b/docs/recipes/web-endpoint.mdx
@@ -69,6 +69,17 @@ async def shutdown():
         await provider.close()
 ```
 
+### Shortcut for simple scripts: a provider recipe string
+
+For a one-off script (not a pooled server) you can skip constructing the provider yourself:
+
+```python
+async with Agent(provider="anthropic:claude-haiku-4-5", prompt="...") as agent:
+    print((await agent.run("hi")).answer)
+```
+
+`provider="vendor:model"` builds the provider for you — reading the API key from the environment — the same way `database_url` builds an engine, and `async with` closes it. Supported vendors: `anthropic`, `openai`, `openai-responses`. Pass a provider **instance** when you need full configuration (custom `base_url`, explicit `api_key`, sampling defaults) or when pooling across requests.
+
 ## Switching model or vendor per turn
 
 For a "pick your model per message" chatbot:

--- a/packages/python/examples/23_per_turn_model_and_ownership.py
+++ b/packages/python/examples/23_per_turn_model_and_ownership.py
@@ -1,0 +1,89 @@
+"""Example 23: Per-turn model selection + provider recipe form + pooling.
+
+Shows three things you want when building chatbots / web endpoints:
+
+1. Per-turn model override — pass ``model=`` to ``run()`` to switch model
+   for a single turn without rebuilding the agent. The model actually used
+   is recorded per LLM call (correct billing/observability).
+
+2. Provider recipe form — ``provider="anthropic:claude-haiku-4-5"`` builds
+   the provider for you (mirrors ``database_url``), reading the API key from
+   the environment. ``async with`` closes it. Pass a provider instance when
+   you need full configuration.
+
+3. Pooling — reuse one provider instance across many agents. ``close()``
+   would close the shared provider, so do NOT call it per request; close
+   the pooled provider once at shutdown.
+
+See docs/recipes/web-endpoint.mdx for the full architecture.
+
+Run:
+    ANTHROPIC_API_KEY=sk-... python examples/23_per_turn_model_and_ownership.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from dendrux import Agent
+from dendrux.llm.anthropic import AnthropicProvider
+from dendrux.store import RunStore
+
+load_dotenv(Path(__file__).resolve().parents[3] / ".env")
+
+
+async def per_turn_model(db_url: str) -> None:
+    """One agent, two turns, two different models — recorded correctly."""
+    print("\n=== 1. Per-turn model override (recipe-form provider) ===")
+    # Recipe-string provider: the agent builds it, async with closes it.
+    async with Agent(
+        provider="anthropic:claude-haiku-4-5",  # default model
+        prompt="Reply in one short sentence.",
+        database_url=db_url,
+        name="chat",
+    ) as agent:
+        default = await agent.run("Say hello.")
+        overridden = await agent.run("Say hello.", model="claude-sonnet-4-6")
+
+    async with RunStore.from_database_url(db_url) as store:
+        for label, result in [("default", default), ("override", overridden)]:
+            calls = await store.get_llm_calls(result.run_id)
+            print(f"  {label:9} -> recorded model: {calls[0].model}")
+
+
+async def pooled_provider() -> None:
+    """One provider instance reused across many agents, closed once.
+
+    close() would close the shared provider, so we do NOT call it per
+    request — the lightweight agent is garbage-collected and we close the
+    pooled provider once at shutdown. (In a real app you'd also share one
+    engine via ``state_store=`` or ``DENDRUX_DATABASE_URL`` rather than a
+    per-agent ``database_url``; these agents run ephemerally to stay focused.)
+    """
+    print("\n=== 2. Pooled provider (don't close() per request) ===")
+    provider = AnthropicProvider(model="claude-haiku-4-5")  # built once, reused
+    try:
+        for i in (1, 2):
+            agent = Agent(provider=provider, prompt="Reply in one word.")
+            result = await agent.run("Ping?")  # no agent.close() -> provider stays open
+            print(f"  request {i}: {result.answer!r}  (provider reused)")
+    finally:
+        await provider.close()  # close the pooled provider once
+    print("  pooled provider closed at shutdown.")
+
+
+async def main() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        db_url = f"sqlite+aiosqlite:///{tmp}/ex23.db"
+        await per_turn_model(db_url)
+        await pooled_provider()
+    print("\nDone — recipe-form provider closed by `async with`;")
+    print("pooled instance closed once at shutdown.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/python/examples/24_mcp_recipe_provider.py
+++ b/packages/python/examples/24_mcp_recipe_provider.py
@@ -1,0 +1,62 @@
+"""Example 24: MCP against a current server + the provider recipe form.
+
+A "does it still work" check using the newer pieces together:
+
+  - provider recipe string: ``provider="anthropic:claude-haiku-4-5"``
+    (dendrux builds the provider; mirrors database_url)
+  - a different MCP server than the filesystem one: the official
+    ``@modelcontextprotocol/server-everything`` conformance server, which
+    exposes simple tools (echo, get-sum, get-env, ...) for exercising an
+    MCP client. Note the current server names its add tool ``get-sum`` —
+    dendrux discovers whatever the server advertises, so it just works.
+
+Prerequisites:
+    - Node.js + npx
+    - ANTHROPIC_API_KEY in .env
+
+Run:
+    ANTHROPIC_API_KEY=sk-... python examples/24_mcp_recipe_provider.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from dendrux import Agent
+from dendrux.mcp import MCPServer
+
+load_dotenv(Path(__file__).resolve().parents[3] / ".env")
+
+
+async def main() -> None:
+    server = MCPServer(
+        "everything",
+        command=["npx", "-y", "@modelcontextprotocol/server-everything"],
+    )
+    async with Agent(
+        name="EverythingAgent",
+        provider="anthropic:claude-haiku-4-5",  # recipe-form provider (new)
+        prompt=(
+            "You can call tools exposed by the 'everything' MCP server. "
+            "Use the available arithmetic tool (named get-sum) to add numbers, "
+            "then confirm the result."
+        ),
+        tool_sources=[server],
+        max_iterations=6,
+    ) as agent:
+        # Prove discovery worked against the current server structure.
+        lookups = await agent.get_tool_lookups()
+        tool_names = sorted(lookups.fn.keys())
+        print(f"Discovered {len(tool_names)} MCP tool(s): {tool_names[:8]}")
+
+        result = await agent.run("Compute 25 + 17 using the arithmetic tool.")
+        print(f"\nStatus: {result.status.value}")
+        print(f"Answer: {result.answer}")
+        print(f"Iterations: {result.iteration_count}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/python/src/dendrux/agent.py
+++ b/packages/python/src/dendrux/agent.py
@@ -113,6 +113,40 @@ async def _verify_schema_initialized(engine: AsyncEngine, url: str) -> None:
         raise SchemaNotInitializedError()
 
 
+def _build_provider_from_spec(spec: str) -> LLMProvider:
+    """Build a provider from a ``"vendor:model"`` recipe string.
+
+    A convenience that mirrors ``database_url``: hand the agent a recipe
+    string and it constructs the provider (reading the API key from the
+    environment). Supported vendors: ``anthropic``, ``openai``,
+    ``openai-responses``. Pass a provider instance for full configuration.
+    """
+    vendor, sep, model = spec.partition(":")
+    vendor = vendor.strip().lower()
+    model = model.strip()
+    if not sep or not model:
+        raise ValueError(
+            f"Invalid provider spec {spec!r}. Use 'vendor:model', "
+            "e.g. 'anthropic:claude-haiku-4-5'."
+        )
+    if vendor == "anthropic":
+        from dendrux.llm.anthropic import AnthropicProvider
+
+        return AnthropicProvider(model=model)
+    if vendor == "openai":
+        from dendrux.llm.openai import OpenAIProvider
+
+        return OpenAIProvider(model=model)
+    if vendor == "openai-responses":
+        from dendrux.llm.openai_responses import OpenAIResponsesProvider
+
+        return OpenAIResponsesProvider(model=model)
+    raise ValueError(
+        f"Unknown provider vendor {vendor!r}. Supported: anthropic, openai, "
+        "openai-responses. Or pass a provider instance you construct yourself."
+    )
+
+
 class Agent:
     """Dendrux agent — definition and runtime facade.
 
@@ -149,7 +183,7 @@ class Agent:
     def __init__(
         self,
         *,
-        provider: LLMProvider,
+        provider: LLMProvider | str,
         prompt: str,
         name: str = ...,
         tools: list[Callable[..., Any]] = ...,
@@ -174,7 +208,7 @@ class Agent:
     def __init__(
         self,
         *,
-        provider: LLMProvider | None = ...,
+        provider: LLMProvider | str | None = ...,
         name: str = ...,
         prompt: str = ...,
         tools: list[Callable[..., Any]] = ...,
@@ -206,7 +240,7 @@ class Agent:
         max_delegation_depth: int | None | _UnsetType = _UNSET,
         loop: Loop | None = None,
         output_type: type[BaseModel] | None = None,
-        provider: LLMProvider | None | _UnsetType = _UNSET,
+        provider: LLMProvider | str | None | _UnsetType = _UNSET,
         database_url: str | None = None,
         database_options: dict[str, Any] | None = None,
         state_store: StateStore | None = None,
@@ -251,7 +285,14 @@ class Agent:
         self._output_type: type[BaseModel] | None = output_type
 
         # --- Provider ---
-        self._provider: LLMProvider | None = None if isinstance(provider, _UnsetType) else provider
+        # A "vendor:model" recipe string builds the provider for you (mirrors
+        # how database_url builds an engine). A provider instance is used as-is.
+        _resolved_provider = None if isinstance(provider, _UnsetType) else provider
+        self._provider: LLMProvider | None = (
+            _build_provider_from_spec(_resolved_provider)
+            if isinstance(_resolved_provider, str)
+            else _resolved_provider
+        )
 
         # --- Persistence ---
         if database_url is not None and state_store is not None:
@@ -1802,6 +1843,11 @@ class Agent:
         Only disposes the private engine created from an explicit database_url.
         The shared global engine (from DENDRUX_DATABASE_URL env var) is NOT
         owned by this agent and is left untouched.
+
+        When pooling a provider or ``MCPServer`` across many agents/requests,
+        do not call ``close()`` per request (it would close the shared object);
+        let the lightweight agent be garbage-collected and close the pooled
+        objects yourself at shutdown. See the web-endpoint recipe.
         """
         for source in self._tool_sources:
             try:

--- a/packages/python/tests/unit/test_agent.py
+++ b/packages/python/tests/unit/test_agent.py
@@ -543,6 +543,31 @@ class TestAgentLifecycle:
             assert a is agent
         provider.close.assert_awaited_once()
 
+    async def test_recipe_string_builds_provider(self, monkeypatch):
+        """A 'vendor:model' string builds the provider for you."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        from dendrux.llm.anthropic import AnthropicProvider
+
+        agent = Agent(provider="anthropic:claude-haiku-4-5", prompt="Hello.")
+        assert isinstance(agent._provider, AnthropicProvider)
+        assert agent._provider.model == "claude-haiku-4-5"
+
+    async def test_recipe_string_provider_is_closed(self, monkeypatch):
+        """A recipe-built provider is closed by close() like any other."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        agent = Agent(provider="anthropic:claude-haiku-4-5", prompt="Hello.")
+        agent._provider.close = AsyncMock()  # type: ignore[union-attr]
+        await agent.close()
+        agent._provider.close.assert_awaited_once()  # type: ignore[union-attr]
+
+    async def test_invalid_provider_spec_raises(self):
+        from dendrux.agent import _build_provider_from_spec
+
+        with pytest.raises(ValueError, match="vendor:model"):
+            _build_provider_from_spec("anthropic")  # missing model
+        with pytest.raises(ValueError, match="Unknown provider vendor"):
+            _build_provider_from_spec("acme:some-model")
+
     async def test_close_without_provider_is_noop(self):
         agent = Agent(prompt="Hello.")
         await agent.close()  # should not raise


### PR DESCRIPTION
## What & why

Follow-up to #16. Adds an ergonomic, **additive** way to construct a provider, plus a worked example for per-turn model + pooling. No behavior changes — existing code is unaffected.

### Provider recipe string
`Agent(provider="anthropic:claude-haiku-4-5")` builds the provider for you, reading the API key from the environment — the same convenience `database_url` gives for the engine. `async with` closes it like any provider.

- Supported vendors: `anthropic`, `openai`, `openai-responses`.
- Pass a provider **instance** when you need full config (custom `base_url`, explicit `api_key`, sampling defaults) or when pooling across requests.
- Invalid specs raise a clear `ValueError`.

### Why additive (not the clean break we discussed)
Testing the clean-break variant against the actual examples showed it silently broke the common instance-form pattern: `async with Agent(provider=AnthropicProvider(...))` stopped closing the provider → `ResourceWarning` for scripts and a real client leak for per-request services. Since a team is building on dendrux, we kept `close()` unchanged and shipped the recipe string as a pure addition. Pooling stays safe via the web-endpoint recipe's "don't call `close()` per request" guidance.

### New example (verified live)
`examples/23_per_turn_model_and_ownership.py` — demonstrates:
1. Per-turn `run(model=...)` with the recorded model read back via `RunStore` (haiku vs sonnet).
2. Recipe-form provider closed by `async with`.
3. Pooling one provider instance across agents, closed once.

Runs clean (no `ResourceWarning`) against the live Anthropic API. Existing examples re-verified unaffected (e.g. `01_hello_world` still warning-free).

## Tests
- `test_recipe_string_builds_provider`, `test_recipe_string_provider_is_closed`, `test_invalid_provider_spec_raises`; existing lifecycle tests unchanged.
- Full suite: 1487 passed, 245 skipped, coverage 90.42%. ruff + format + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)