### PR TITLE
release: dendrux 0.2.0a4

### DIFF
--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dendrux"
-version = "0.2.0a3"
+version = "0.2.0a4"
 description = "The runtime for agents that act in the real world."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Version bump 0.2.0a3 → 0.2.0a4 so the dev team can `pip install --upgrade dendrux`.

## What's in a4 (since a3)
- **fix** (#16): the recorded model now reflects the model actually used per call, so per-turn `run(model="...")` is correct for billing/observability.
- **feat** (#17): `Agent(provider="anthropic:claude-haiku-4-5")` — provider recipe string (mirrors `database_url`). Vendors: anthropic, openai, openai-responses.
- **docs**: "dendrux in a web or chat endpoint" recipe (build-per-request, share engine/MCP/provider, resume with consistent config).
- **examples**: `23_per_turn_model_and_ownership.py`, `24_mcp_recipe_provider.py` (MCP conformance vs server-everything).

No breaking changes — additive only.

## Build verification
`python -m build` → `dendrux-0.2.0a4` sdist + wheel; `twine check` PASSED both. Full suite green (1487 passed, 90.42% coverage), ruff/mypy clean.

After merge: tag `v0.2.0a4` and `twine upload` to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)