### PR TITLE
feat: surface model reasoning/thinking (Anthropic)

### DIFF
--- a/packages/python/examples/25_reasoning.py
+++ b/packages/python/examples/25_reasoning.py
@@ -1,0 +1,99 @@
+"""Reasoning / thinking — surface a model's reasoning summary + token count.
+
+Phase 1 wires reasoning through the provider's ``complete()`` path. This
+example calls the Anthropic provider directly to show, for a thinking-enabled
+call:
+  - the answer text
+  - the summarized thinking the model surfaced (``response.reasoning``)
+  - the reasoning token count (billed within output tokens)
+  - how many reasoning blocks were captured for multi-turn replay
+
+It contrasts that with the default (thinking off), which surfaces nothing —
+proving the feature is opt-in and backward-compatible.
+
+(Surfacing reasoning through ``agent.run()`` lands with the runner roll-up +
+``RunResult.reasoning`` step; this example exercises the provider path that is
+wired today.)
+
+Run with:
+    ANTHROPIC_API_KEY=sk-... python examples/25_reasoning.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from dendrux.llm.anthropic import AnthropicProvider
+from dendrux.types import Message, Role, StreamEventType
+
+# Load .env from repo root (examples/ → python/ → packages/ → dendrux/)
+load_dotenv(Path(__file__).resolve().parents[3] / ".env")
+
+PROMPT = (
+    "A bat and a ball cost $1.10 in total. The bat costs $1.00 more than the "
+    "ball. How much does the ball cost? Give the number and one line of why."
+)
+
+
+async def main() -> None:
+    # --- Thinking ON: adaptive, high effort, summary visible ---
+    async with AnthropicProvider(
+        model="claude-sonnet-4-6",
+        thinking=True,
+        effort="high",
+        show_thinking=True,
+        max_tokens=2000,
+    ) as provider:
+        resp = await provider.complete([Message(role=Role.USER, content=PROMPT)])
+
+    print("=== thinking ON (adaptive, effort=high) ===")
+    print("\n[reasoning summary]")
+    print(resp.reasoning or "(none returned)")
+    print("\n[answer]")
+    print(resp.text or "")
+    print(
+        f"\n[usage] output_tokens={resp.usage.output_tokens} "
+        f"reasoning_tokens={resp.usage.reasoning_tokens} "
+        f"reasoning_blocks={len(resp.reasoning_blocks or [])}"
+    )
+
+    # --- Thinking OFF (default): backward-compatible, nothing surfaced ---
+    async with AnthropicProvider(model="claude-sonnet-4-6", max_tokens=2000) as provider:
+        resp = await provider.complete([Message(role=Role.USER, content=PROMPT)])
+
+    print("\n=== thinking OFF (default) ===")
+    print(f"reasoning is None: {resp.reasoning is None}")
+    print(f"reasoning_blocks is None: {resp.reasoning_blocks is None}")
+    print("\n[answer]")
+    print(resp.text or "")
+
+    # --- Thinking ON, STREAMING: watch reasoning stream before the answer ---
+    print("\n=== thinking ON, STREAMING ===")
+    async with AnthropicProvider(
+        model="claude-sonnet-4-6", thinking=True, effort="high", max_tokens=2000
+    ) as provider:
+        in_reasoning = in_answer = False
+        async for ev in provider.complete_stream([Message(role=Role.USER, content=PROMPT)]):
+            if ev.type == StreamEventType.REASONING_DELTA:
+                if not in_reasoning:
+                    print("[thinking] ", end="", flush=True)
+                    in_reasoning = True
+                print(ev.text, end="", flush=True)
+            elif ev.type == StreamEventType.TEXT_DELTA:
+                if not in_answer:
+                    print("\n\n[answer] ", end="", flush=True)
+                    in_answer = True
+                print(ev.text, end="", flush=True)
+            elif ev.type == StreamEventType.DONE:
+                u = ev.raw.usage
+                print(
+                    f"\n\n[usage] output_tokens={u.output_tokens} "
+                    f"reasoning_tokens={u.reasoning_tokens}"
+                )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/python/src/dendrux/llm/anthropic.py
+++ b/packages/python/src/dendrux/llm/anthropic.py
@@ -54,6 +54,24 @@ _SUPPORTED_KWARGS = frozenset(
     {"temperature", "top_p", "top_k", "stop_sequences", "model", "max_tokens"}
 )
 
+# Dendrux effort vocabulary → Anthropic. "extra" is the consumer label for
+# "xhigh"; every other value passes through (Anthropic validates it).
+_EFFORT_ALIASES = {"extra": "xhigh"}
+
+
+def _normalize_effort(effort: str) -> str:
+    """Map a Dendrux effort alias to Anthropic's vocabulary."""
+    return _EFFORT_ALIASES.get(effort, effort)
+
+
+def _reasoning_tokens_from_details(details: Any) -> int | None:
+    """Read thinking_tokens from output_tokens_details (dict or typed object)."""
+    if isinstance(details, dict):
+        return details.get("thinking_tokens")
+    if details is not None:
+        return getattr(details, "thinking_tokens", None)
+    return None
+
 
 class AnthropicProvider(LLMProvider):
     """Anthropic Messages API provider.
@@ -77,7 +95,7 @@ class AnthropicProvider(LLMProvider):
         supports_tool_call_ids=True,
         supports_streaming=True,
         supports_streaming_tool_deltas=True,
-        supports_thinking=False,  # Not implemented yet
+        supports_thinking=True,
         supports_multimodal=False,  # Not implemented yet
         supports_system_prompt=True,
         supports_parallel_tool_calls=True,
@@ -92,6 +110,10 @@ class AnthropicProvider(LLMProvider):
         api_key: str | None = None,
         max_tokens: int = 16_000,
         temperature: float | None = None,
+        thinking: bool = False,
+        effort: str | None = None,
+        show_thinking: bool = True,
+        thinking_budget: int | None = None,
         timeout: float = 120.0,
         max_retries: int = 3,
         cache_ttl: Literal["5m", "1h"] | None = None,
@@ -103,6 +125,16 @@ class AnthropicProvider(LLMProvider):
             api_key: API key. Defaults to ANTHROPIC_API_KEY env var.
             max_tokens: Maximum output tokens per call. Override per-call via kwargs.
             temperature: Sampling temperature. None = model default. Override per-call.
+            thinking: Enable extended/adaptive thinking. Default False (off).
+                When on, ``temperature`` is omitted (incompatible with thinking).
+            effort: Thinking effort — low|medium|high|xhigh|max ("extra"→xhigh).
+                Sent as ``output_config.effort`` when thinking is on.
+            show_thinking: When thinking is on, ``True`` returns summarized
+                thinking text (display=summarized); ``False`` omits it
+                (display=omitted, faster first token). Default True.
+            thinking_budget: Force legacy manual thinking with a fixed
+                ``budget_tokens`` (older models / precise cost). Default None
+                → adaptive thinking.
             timeout: HTTP request timeout in seconds.
             max_retries: Number of automatic retries on transient errors.
             cache_ttl: Anthropic prompt-cache TTL. ``None`` (default) omits the
@@ -123,6 +155,10 @@ class AnthropicProvider(LLMProvider):
         self._model = model
         self._max_tokens = max_tokens
         self._temperature = temperature
+        self._thinking = thinking
+        self._effort = effort
+        self._show_thinking = show_thinking
+        self._thinking_budget = thinking_budget
         self._timeout = timeout
         self._cache_ttl = cache_ttl
 
@@ -214,7 +250,18 @@ class AnthropicProvider(LLMProvider):
             "tools": api_tools,
         }
 
-        if "temperature" in kwargs:
+        # Resolve thinking controls — per-call kwargs override constructor.
+        thinking_on = kwargs.pop("thinking", self._thinking)
+        effort = kwargs.pop("effort", self._effort)
+        show_thinking = kwargs.pop("show_thinking", self._show_thinking)
+        thinking_budget = kwargs.pop("thinking_budget", self._thinking_budget)
+        if thinking_on:
+            self._apply_thinking(api_kwargs, effort, show_thinking, thinking_budget)
+
+        # Temperature is incompatible with thinking — only send it when off.
+        if thinking_on:
+            kwargs.pop("temperature", None)
+        elif "temperature" in kwargs:
             api_kwargs["temperature"] = kwargs.pop("temperature")
         elif self._temperature is not None:
             api_kwargs["temperature"] = self._temperature
@@ -225,6 +272,31 @@ class AnthropicProvider(LLMProvider):
 
         captured_request = {k: v for k, v in api_kwargs.items() if v is not anthropic.NOT_GIVEN}
         return api_kwargs, captured_request
+
+    def _apply_thinking(
+        self,
+        api_kwargs: dict[str, Any],
+        effort: str | None,
+        show_thinking: bool,
+        thinking_budget: int | None,
+    ) -> None:
+        """Build the ``thinking`` + ``output_config`` API params.
+
+        Adaptive mode by default (the only mode on current 4.6–4.8 / Fable /
+        Mythos models); a ``thinking_budget`` switches to legacy manual mode
+        for older models or fixed-cost workloads.
+        """
+        display = "summarized" if show_thinking else "omitted"
+        if thinking_budget is not None:
+            api_kwargs["thinking"] = {
+                "type": "enabled",
+                "budget_tokens": thinking_budget,
+                "display": display,
+            }
+        else:
+            api_kwargs["thinking"] = {"type": "adaptive", "display": display}
+        if effort is not None:
+            api_kwargs["output_config"] = {"effort": _normalize_effort(effort)}
 
     async def complete(
         self,
@@ -315,6 +387,9 @@ class AnthropicProvider(LLMProvider):
         # Accumulators for building the final LLMResponse
         text_parts: list[str] = []
         tool_calls: list[ToolCall] = []
+        # Thinking-token count arrives on the message_delta event, not on the
+        # streamed final message's usage — capture it here.
+        stream_reasoning_tokens: int | None = None
 
         # Per-block state for tool call assembly
         _current_tool_name: str | None = None
@@ -345,6 +420,15 @@ class AnthropicProvider(LLMProvider):
                                 type=StreamEventType.TEXT_DELTA,
                                 text=delta.text,
                             )
+                        elif delta.type == "thinking_delta":
+                            yield StreamEvent(
+                                type=StreamEventType.REASONING_DELTA,
+                                text=delta.thinking,
+                            )
+                        elif delta.type == "signature_delta":
+                            # Carried on the final message's blocks; nothing to
+                            # surface live.
+                            pass
                         elif delta.type == "input_json_delta":
                             _current_tool_json_parts.append(delta.partial_json)
 
@@ -374,6 +458,14 @@ class AnthropicProvider(LLMProvider):
                             _current_tool_id = None
                             _current_tool_json_parts = []
 
+                    elif event.type == "message_delta":
+                        details = getattr(
+                            getattr(event, "usage", None), "output_tokens_details", None
+                        )
+                        captured = _reasoning_tokens_from_details(details)
+                        if captured is not None:
+                            stream_reasoning_tokens = captured
+
                 # Get the final message for usage stats and provider response
                 final_message = await stream.get_final_message()
 
@@ -384,21 +476,18 @@ class AnthropicProvider(LLMProvider):
         finally:
             end_call_attempt_tracking(attempt_token)
 
-        usage = UsageStats(
-            input_tokens=final_message.usage.input_tokens,
-            output_tokens=final_message.usage.output_tokens,
-            total_tokens=final_message.usage.input_tokens + final_message.usage.output_tokens,
-            cache_read_input_tokens=getattr(final_message.usage, "cache_read_input_tokens", None),
-            cache_creation_input_tokens=getattr(
-                final_message.usage, "cache_creation_input_tokens", None
-            ),
-        )
+        usage = self._usage_from_response(final_message.usage)
+        if usage.reasoning_tokens is None and stream_reasoning_tokens is not None:
+            usage.reasoning_tokens = stream_reasoning_tokens
+        reasoning, reasoning_blocks = self._extract_reasoning(final_message.content)
 
         llm_response = LLMResponse(
             text="".join(text_parts) if text_parts else None,
             tool_calls=tool_calls if tool_calls else None,
             raw=final_message,
             usage=usage,
+            reasoning=reasoning,
+            reasoning_blocks=reasoning_blocks,
         )
         llm_response.provider_request = captured_request
         llm_response.model = captured_request["model"]
@@ -517,6 +606,48 @@ class AnthropicProvider(LLMProvider):
     # Inbound conversions: Anthropic → Dendrux
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _usage_from_response(usage: Any) -> UsageStats:
+        """Build UsageStats from an Anthropic Usage object.
+
+        ``reasoning_tokens`` is read from ``output_tokens_details.thinking_tokens``
+        when the SDK reports it (None otherwise) — these are billed within
+        ``output_tokens``.
+        """
+        details = getattr(usage, "output_tokens_details", None)
+        reasoning_tokens = _reasoning_tokens_from_details(details)
+        return UsageStats(
+            input_tokens=usage.input_tokens,
+            output_tokens=usage.output_tokens,
+            total_tokens=usage.input_tokens + usage.output_tokens,
+            cache_read_input_tokens=getattr(usage, "cache_read_input_tokens", None),
+            cache_creation_input_tokens=getattr(usage, "cache_creation_input_tokens", None),
+            reasoning_tokens=reasoning_tokens,
+        )
+
+    @staticmethod
+    def _extract_reasoning(content: list[Any]) -> tuple[str | None, list[Any] | None]:
+        """Pull reasoning summary text + replay blocks from message content.
+
+        Keeps the full thinking/redacted_thinking blocks (incl. signature) for
+        multi-turn replay; surfaces the summary text when present (an
+        ``omitted`` display yields blocks with empty thinking text).
+        """
+        reasoning_parts: list[str] = []
+        reasoning_blocks: list[Any] = []
+        for block in content:
+            if block.type in ("thinking", "redacted_thinking"):
+                reasoning_blocks.append(
+                    block.model_dump() if hasattr(block, "model_dump") else block
+                )
+                thinking_text = getattr(block, "thinking", None)
+                if thinking_text:
+                    reasoning_parts.append(thinking_text)
+        return (
+            "".join(reasoning_parts) if reasoning_parts else None,
+            reasoning_blocks if reasoning_blocks else None,
+        )
+
     def _normalize_structured_response(self, response: anthropic.types.Message) -> LLMResponse:
         """Extract structured output from a forced tool_use response.
 
@@ -536,15 +667,7 @@ class AnthropicProvider(LLMProvider):
                 "'structured_output' but none was found in the response."
             )
 
-        usage = UsageStats(
-            input_tokens=response.usage.input_tokens,
-            output_tokens=response.usage.output_tokens,
-            total_tokens=response.usage.input_tokens + response.usage.output_tokens,
-            cache_read_input_tokens=getattr(response.usage, "cache_read_input_tokens", None),
-            cache_creation_input_tokens=getattr(
-                response.usage, "cache_creation_input_tokens", None
-            ),
-        )
+        usage = self._usage_from_response(response.usage)
 
         return LLMResponse(
             text=json.dumps(structured_data),
@@ -575,19 +698,14 @@ class AnthropicProvider(LLMProvider):
                     )
                 )
 
-        usage = UsageStats(
-            input_tokens=response.usage.input_tokens,
-            output_tokens=response.usage.output_tokens,
-            total_tokens=response.usage.input_tokens + response.usage.output_tokens,
-            cache_read_input_tokens=getattr(response.usage, "cache_read_input_tokens", None),
-            cache_creation_input_tokens=getattr(
-                response.usage, "cache_creation_input_tokens", None
-            ),
-        )
+        reasoning, reasoning_blocks = self._extract_reasoning(response.content)
+        usage = self._usage_from_response(response.usage)
 
         return LLMResponse(
             text="".join(text_parts) if text_parts else None,
             tool_calls=tool_calls if tool_calls else None,
             raw=response,
             usage=usage,
+            reasoning=reasoning,
+            reasoning_blocks=reasoning_blocks,
         )

--- a/packages/python/src/dendrux/types.py
+++ b/packages/python/src/dendrux/types.py
@@ -196,6 +196,10 @@ class UsageStats:
     OpenAI-compatible backends without prompt_tokens_details), or an int
     (possibly 0) when the provider did report it. This distinction lets
     downstream tooling tell "didn't report" apart from "reported zero".
+
+    ``reasoning_tokens`` is the count of internal reasoning/thinking tokens
+    the model billed within ``output_tokens`` (Anthropic thinking, OpenAI
+    reasoning). ``None`` when the provider did not report it.
     """
 
     input_tokens: int = 0
@@ -204,6 +208,7 @@ class UsageStats:
     cost_usd: float | None = None
     cache_read_input_tokens: int | None = None
     cache_creation_input_tokens: int | None = None
+    reasoning_tokens: int | None = None
 
 
 @dataclass(frozen=True)
@@ -259,6 +264,13 @@ class LLMResponse:
     # The model actually used for this call. Honors a per-call ``model=`` override;
     # falls back to the provider's configured model when a provider leaves it unset.
     model: str | None = None
+    # Reasoning/thinking the model surfaced (summary text — never raw CoT).
+    # None unless thinking was enabled and a summary/display was requested.
+    reasoning: str | None = None
+    # Opaque provider reasoning artifacts to replay verbatim for multi-turn
+    # tool use (Anthropic thinking blocks + signature, OpenAI reasoning items).
+    # Stored and round-tripped as-is; never interpreted by Dendrux.
+    reasoning_blocks: list[Any] | None = None
 
 
 @dataclass(frozen=True)
@@ -563,12 +575,15 @@ class StreamEventType(StrEnum):
     """Types of events emitted during streaming LLM responses.
 
     TEXT_DELTA: Incremental text token from the LLM.
+    REASONING_DELTA: Incremental reasoning/thinking token (``text`` carries it).
+        Only emitted when thinking is enabled; arrives before TEXT_DELTA.
     TOOL_USE_START: A tool call block has begun (name known, args pending).
     TOOL_USE_END: A tool call is fully assembled and ready to execute.
     DONE: Stream finished. ``raw`` carries the full ``LLMResponse``.
     """
 
     TEXT_DELTA = "text_delta"
+    REASONING_DELTA = "reasoning_delta"
     TOOL_USE_START = "tool_use_start"
     TOOL_USE_END = "tool_use_end"
     DONE = "done"
@@ -610,6 +625,7 @@ class RunEventType(StrEnum):
 
     LLM output events (translated from provider StreamEvent):
         TEXT_DELTA: Incremental text token from the LLM.
+        REASONING_DELTA: Incremental reasoning/thinking token (in ``text``).
         TOOL_USE_START: A tool call block has begun (name known, args pending).
         TOOL_USE_END: A tool call is fully assembled.
 
@@ -627,6 +643,7 @@ class RunEventType(StrEnum):
 
     # LLM output (translated from provider StreamEvent)
     TEXT_DELTA = "text_delta"
+    REASONING_DELTA = "reasoning_delta"
     TOOL_USE_START = "tool_use_start"
     TOOL_USE_END = "tool_use_end"
 

--- a/packages/python/tests/unit/test_anthropic.py
+++ b/packages/python/tests/unit/test_anthropic.py
@@ -67,8 +67,8 @@ class TestCapabilities:
     def test_streaming_tool_deltas_implemented(self, provider: AnthropicProvider) -> None:
         assert provider.capabilities.supports_streaming_tool_deltas is True
 
-    def test_thinking_not_implemented(self, provider: AnthropicProvider) -> None:
-        assert provider.capabilities.supports_thinking is False
+    def test_thinking_implemented(self, provider: AnthropicProvider) -> None:
+        assert provider.capabilities.supports_thinking is True
 
     def test_multimodal_not_implemented(self, provider: AnthropicProvider) -> None:
         assert provider.capabilities.supports_multimodal is False
@@ -662,6 +662,8 @@ class _FakeDelta:
     type: str
     text: str | None = None
     partial_json: str | None = None
+    thinking: str | None = None
+    signature: str | None = None
 
 
 @dataclass
@@ -670,6 +672,7 @@ class _FakeStreamEvent:
     content_block: _FakeContentBlock | None = None
     delta: _FakeDelta | None = None
     index: int = 0
+    usage: object | None = None
 
 
 class _FakeStream:
@@ -1013,3 +1016,256 @@ class TestApiKeyValidation:
     def test_accepts_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-from-env")
         AnthropicProvider(model="claude-sonnet-4-6")
+
+
+# ------------------------------------------------------------------
+# Thinking / reasoning (Phase 1 — complete() path)
+# ------------------------------------------------------------------
+
+
+@dataclass
+class _FakeThinkingBlock:
+    type: str
+    thinking: str = ""
+    signature: str = ""
+
+    def model_dump(self) -> dict:
+        return {"type": self.type, "thinking": self.thinking, "signature": self.signature}
+
+
+@dataclass
+class _FakeOutputTokensDetails:
+    thinking_tokens: int
+
+
+@dataclass
+class _FakeUsage:
+    input_tokens: int = 100
+    output_tokens: int = 50
+    output_tokens_details: object | None = None
+
+
+@dataclass
+class _FakeResponse:
+    content: list
+    usage: _FakeUsage
+
+
+class TestThinkingApiKwargs:
+    """thinking/effort/show_thinking/thinking_budget → API request shape."""
+
+    @staticmethod
+    def _build(provider: AnthropicProvider, **kwargs: object) -> dict:
+        api_kwargs, _ = provider._build_api_kwargs(
+            [Message(role=Role.USER, content="hi")], None, dict(kwargs)
+        )
+        return api_kwargs
+
+    def test_off_by_default(self, provider: AnthropicProvider) -> None:
+        api_kwargs = self._build(provider)
+        assert "thinking" not in api_kwargs
+        assert "output_config" not in api_kwargs
+
+    def test_thinking_on_adaptive(self, provider: AnthropicProvider) -> None:
+        api_kwargs = self._build(provider, thinking=True)
+        assert api_kwargs["thinking"] == {"type": "adaptive", "display": "summarized"}
+
+    def test_effort_to_output_config(self, provider: AnthropicProvider) -> None:
+        api_kwargs = self._build(provider, thinking=True, effort="high")
+        assert api_kwargs["output_config"] == {"effort": "high"}
+
+    def test_effort_extra_alias_to_xhigh(self, provider: AnthropicProvider) -> None:
+        api_kwargs = self._build(provider, thinking=True, effort="extra")
+        assert api_kwargs["output_config"] == {"effort": "xhigh"}
+
+    def test_show_thinking_false_omits(self, provider: AnthropicProvider) -> None:
+        api_kwargs = self._build(provider, thinking=True, show_thinking=False)
+        assert api_kwargs["thinking"]["display"] == "omitted"
+
+    def test_thinking_budget_uses_manual_mode(self, provider: AnthropicProvider) -> None:
+        api_kwargs = self._build(provider, thinking=True, thinking_budget=10_000)
+        assert api_kwargs["thinking"] == {
+            "type": "enabled",
+            "budget_tokens": 10_000,
+            "display": "summarized",
+        }
+
+    def test_temperature_dropped_when_thinking_on(self) -> None:
+        p = AnthropicProvider(api_key="sk-test", model="claude-sonnet-4-6", temperature=0.5)
+        assert "temperature" not in self._build(p, thinking=True)
+
+    def test_temperature_kept_when_thinking_off(self) -> None:
+        p = AnthropicProvider(api_key="sk-test", model="claude-sonnet-4-6", temperature=0.5)
+        assert self._build(p)["temperature"] == 0.5
+
+    def test_constructor_default_thinking(self) -> None:
+        p = AnthropicProvider(
+            api_key="sk-test", model="claude-opus-4-8", thinking=True, effort="medium"
+        )
+        api_kwargs = self._build(p)
+        assert api_kwargs["thinking"]["type"] == "adaptive"
+        assert api_kwargs["output_config"] == {"effort": "medium"}
+
+    def test_per_call_overrides_constructor(self) -> None:
+        p = AnthropicProvider(api_key="sk-test", model="claude-opus-4-8", thinking=True)
+        assert "thinking" not in self._build(p, thinking=False)
+
+
+class TestThinkingNormalize:
+    """_normalize_response reads thinking blocks + reasoning_tokens."""
+
+    def test_reads_thinking_text_and_blocks(self, provider: AnthropicProvider) -> None:
+        resp = _FakeResponse(
+            content=[
+                _FakeThinkingBlock(type="thinking", thinking="Let me think...", signature="sig123"),
+                TextBlock(type="text", text="The answer is 21", citations=None),
+            ],
+            usage=_FakeUsage(),
+        )
+        result = provider._normalize_response(resp)
+        assert result.text == "The answer is 21"
+        assert result.reasoning == "Let me think..."
+        assert result.reasoning_blocks is not None
+        assert result.reasoning_blocks[0]["signature"] == "sig123"
+
+    def test_redacted_thinking_kept_without_text(self, provider: AnthropicProvider) -> None:
+        resp = _FakeResponse(
+            content=[
+                _FakeThinkingBlock(type="redacted_thinking", thinking="", signature="enc"),
+                TextBlock(type="text", text="ok", citations=None),
+            ],
+            usage=_FakeUsage(),
+        )
+        result = provider._normalize_response(resp)
+        assert result.reasoning is None
+        assert result.reasoning_blocks[0]["type"] == "redacted_thinking"
+
+    def test_reasoning_tokens_from_usage_details_object(self, provider: AnthropicProvider) -> None:
+        resp = _FakeResponse(
+            content=[TextBlock(type="text", text="hi", citations=None)],
+            usage=_FakeUsage(output_tokens_details=_FakeOutputTokensDetails(thinking_tokens=312)),
+        )
+        result = provider._normalize_response(resp)
+        assert result.usage.reasoning_tokens == 312
+
+    def test_reasoning_tokens_from_usage_details_dict(self, provider: AnthropicProvider) -> None:
+        # The live Anthropic SDK delivers output_tokens_details as a plain dict.
+        resp = _FakeResponse(
+            content=[TextBlock(type="text", text="hi", citations=None)],
+            usage=_FakeUsage(output_tokens_details={"thinking_tokens": 59}),
+        )
+        result = provider._normalize_response(resp)
+        assert result.usage.reasoning_tokens == 59
+
+    def test_bc_no_thinking_leaves_reasoning_none(self, provider: AnthropicProvider) -> None:
+        resp = _FakeResponse(
+            content=[TextBlock(type="text", text="hi", citations=None)],
+            usage=_FakeUsage(),
+        )
+        result = provider._normalize_response(resp)
+        assert result.reasoning is None
+        assert result.reasoning_blocks is None
+        assert result.usage.reasoning_tokens is None
+
+
+@dataclass
+class _FakeFinalMessage:
+    content: list
+    usage: _FakeUsage
+
+    def model_dump(self) -> dict:
+        return {"id": "msg_fake", "type": "message"}
+
+
+class TestThinkingStream:
+    """complete_stream emits REASONING_DELTA + DONE carries reasoning."""
+
+    @staticmethod
+    def _thinking_stream_events() -> list[_FakeStreamEvent]:
+        return [
+            _FakeStreamEvent(
+                type="content_block_start",
+                content_block=_FakeContentBlock(type="thinking"),
+            ),
+            _FakeStreamEvent(
+                type="content_block_delta",
+                delta=_FakeDelta(type="thinking_delta", thinking="Let me "),
+            ),
+            _FakeStreamEvent(
+                type="content_block_delta",
+                delta=_FakeDelta(type="thinking_delta", thinking="reason."),
+            ),
+            _FakeStreamEvent(
+                type="content_block_delta",
+                delta=_FakeDelta(type="signature_delta", signature="sig123"),
+            ),
+            _FakeStreamEvent(type="content_block_stop"),
+            _FakeStreamEvent(
+                type="content_block_start",
+                content_block=_FakeContentBlock(type="text"),
+            ),
+            _FakeStreamEvent(
+                type="content_block_delta",
+                delta=_FakeDelta(type="text_delta", text="The answer."),
+            ),
+            _FakeStreamEvent(type="content_block_stop"),
+            # Thinking-token count arrives on message_delta, not final usage.
+            _FakeStreamEvent(
+                type="message_delta",
+                usage=_FakeUsage(output_tokens_details={"thinking_tokens": 12}),
+            ),
+        ]
+
+    async def test_reasoning_deltas_emitted(self, provider: AnthropicProvider) -> None:
+        # final message usage has NO details — count must come from message_delta.
+        final_msg = _FakeFinalMessage(
+            content=[
+                _FakeThinkingBlock(type="thinking", thinking="Let me reason.", signature="sig123"),
+                TextBlock(type="text", text="The answer.", citations=None),
+            ],
+            usage=_FakeUsage(),
+        )
+        provider._client.messages.stream = MagicMock(
+            return_value=_FakeStream(self._thinking_stream_events(), final_msg)
+        )
+
+        collected = []
+        async for event in provider.complete_stream([Message(role=Role.USER, content="Hi")]):
+            collected.append(event)
+
+        reasoning_events = [e for e in collected if e.type == StreamEventType.REASONING_DELTA]
+        text_events = [e for e in collected if e.type == StreamEventType.TEXT_DELTA]
+        assert [e.text for e in reasoning_events] == ["Let me ", "reason."]
+        assert [e.text for e in text_events] == ["The answer."]
+
+        done = collected[-1]
+        assert done.type == StreamEventType.DONE
+        assert done.raw.reasoning == "Let me reason."
+        assert done.raw.reasoning_blocks[0]["signature"] == "sig123"
+        assert done.raw.usage.reasoning_tokens == 12
+        assert done.raw.text == "The answer."
+
+    async def test_no_reasoning_delta_when_text_only(self, provider: AnthropicProvider) -> None:
+        # BC: a plain text stream emits zero REASONING_DELTA events.
+        final_msg = _FakeFinalMessage(
+            content=[TextBlock(type="text", text="hi", citations=None)],
+            usage=_FakeUsage(),
+        )
+        events = [
+            _FakeStreamEvent(
+                type="content_block_start", content_block=_FakeContentBlock(type="text")
+            ),
+            _FakeStreamEvent(
+                type="content_block_delta", delta=_FakeDelta(type="text_delta", text="hi")
+            ),
+            _FakeStreamEvent(type="content_block_stop"),
+        ]
+        provider._client.messages.stream = MagicMock(return_value=_FakeStream(events, final_msg))
+
+        collected = []
+        async for event in provider.complete_stream([Message(role=Role.USER, content="Hi")]):
+            collected.append(event)
+
+        assert not [e for e in collected if e.type == StreamEventType.REASONING_DELTA]
+        assert collected[-1].raw.reasoning is None
+        assert collected[-1].raw.reasoning_blocks is None


### PR DESCRIPTION
- additive types: UsageStats.reasoning_tokens, LLMResponse.reasoning/reasoning_blocks, REASONING_DELTA stream + run events
- AnthropicProvider: thinking/effort/show_thinking/thinking_budget; adaptive routing + output_config.effort; temperature dropped when thinking on
- read thinking blocks (text + signature) + reasoning_tokens in complete() and streaming (message_delta path)
- example 25_reasoning.py (complete + stream); all default-off, backward-compatible

Authored-By: Anmol Gautam <anmolgautam2428@gmail.com>
Assisted-By: Claude <noreply@anthropic.com>