### PR TITLE
fix: OpenAI Chat sends max_completion_tokens on the official endpoint

### DIFF
--- a/docs/architecture/models.mdx
+++ b/docs/architecture/models.mdx
@@ -1,0 +1,76 @@
+---
+title: Models and providers
+description: The three first-class provider classes, which one to reach for, how OpenAI-compatible backends fit, and the per-model output-token caps that dendrux handles for you.
+---
+
+# Models and providers
+
+A **provider** is the thin adapter between dendrux's universal types and a vendor's HTTP API. You construct one, hand it to `Agent(provider=...)`, and the loop calls it. Providers do shape translation only — no agent-loop awareness, no business logic.
+
+Three first-class provider classes ship in the box. Everything below is read from the `dendrux==0.2.0a4` source.
+
+| Class | Vendor / API | Import |
+| --- | --- | --- |
+| `AnthropicProvider` | Anthropic Messages API | `dendrux.llm.anthropic` |
+| `OpenAIProvider` | OpenAI **Chat Completions** (and any OpenAI-compatible server) | `dendrux.llm.openai` |
+| `OpenAIResponsesProvider` | OpenAI **Responses** API | `dendrux.llm.openai_responses` |
+
+```python
+from dendrux import Agent
+from dendrux.llm.anthropic import AnthropicProvider
+from dendrux.llm.openai import OpenAIProvider
+from dendrux.llm.openai_responses import OpenAIResponsesProvider
+
+agent = Agent(prompt="…", provider=AnthropicProvider(model="claude-opus-4-8"))
+```
+
+## Picking a provider
+
+There are two OpenAI providers because OpenAI runs two different request/response APIs, and they differ in what they can surface.
+
+- **OpenAI, current models** → `OpenAIResponsesProvider`. The Responses API is OpenAI's current direction and the only one that returns **reasoning summaries** (the model's thinking, as text) for gpt-5 / o-series. See [Reasoning and thinking](/docs/architecture/reasoning).
+- **Legacy OpenAI models, or any OpenAI-compatible server** → `OpenAIProvider`. Chat Completions is the universal endpoint. It returns reasoning **token counts** but no reasoning text.
+- **Anthropic** → `AnthropicProvider`.
+
+The Responses API is OpenAI-only. Pointing `OpenAIResponsesProvider` at a non-OpenAI backend will not work — that is exactly the case `OpenAIProvider` covers.
+
+## OpenAI-compatible backends
+
+`OpenAIProvider` speaks plain Chat Completions, so it drives any server that implements that wire format — vLLM, SGLang, Groq, Together, Ollama, LM Studio — by setting `base_url`. There is no separate provider class per backend.
+
+```python
+# vLLM / SGLang / local
+OpenAIProvider(model="meta-llama/Llama-3-70B", base_url="http://localhost:8000/v1", api_key="not-needed")
+
+# Groq
+OpenAIProvider(model="llama-3.3-70b", base_url="https://api.groq.com/openai/v1", api_key="gsk-…")
+```
+
+When `base_url` points away from the official endpoint, dendrux drops OpenAI-specific request fields (the prompt-cache key, the OpenAI-only output-token parameter) that some compatible backends reject. You get the universal request shape automatically.
+
+## The output-token cap is per-API
+
+Every provider takes a constructor default for the maximum output tokens per call and lets you override it per call via kwargs. The wire parameter name differs by API, and dendrux picks the right one for you:
+
+| Provider / endpoint | Wire parameter | Constructor arg |
+| --- | --- | --- |
+| `AnthropicProvider` | `max_tokens` | `max_tokens=` |
+| `OpenAIProvider`, **official** OpenAI endpoint | `max_completion_tokens` | `max_tokens=` |
+| `OpenAIProvider`, **compatible** backend (custom `base_url`) | `max_tokens` | `max_tokens=` |
+| `OpenAIResponsesProvider` | `max_output_tokens` | `max_output_tokens=` |
+
+The OpenAI Chat Completions case is the subtle one. gpt-5 and o-series models **reject** `max_tokens` on Chat Completions with an HTTP 400 (`Unsupported parameter: 'max_tokens' … Use 'max_completion_tokens' instead`); `max_tokens` is deprecated for gpt-4o-era models too. So on the official endpoint `OpenAIProvider` always sends `max_completion_tokens`, which works for gpt-4o, gpt-5, and o-series alike. Compatible backends that still expect the older `max_tokens` keep getting it. The selection is gated on `base_url`, the same way prompt-cache routing is — you do not configure it.
+
+You keep using the friendly constructor name regardless of endpoint:
+
+```python
+# Constructor default applies to every call …
+provider = OpenAIProvider(model="gpt-5.5", max_tokens=4_000)
+
+# … and a per-call kwarg overrides it for one call.
+await agent.run("…", max_tokens=512)
+```
+
+## Per-call overrides
+
+Anything you pass to `agent.run(...)` / `agent.stream(...)` is forwarded to the provider for that call and overrides the constructor default. Common knobs: `model`, `max_tokens`, `temperature`, and the reasoning controls (`thinking`, `effort`) covered in [Reasoning and thinking](/docs/architecture/reasoning). Unknown kwargs are ignored rather than forwarded blindly, so a kwarg meant for one provider will not break another.

--- a/docs/architecture/reasoning.mdx
+++ b/docs/architecture/reasoning.mdx
@@ -1,0 +1,87 @@
+---
+title: Reasoning and thinking
+description: Turn on extended thinking for Anthropic and OpenAI with one switch, control depth and whether the trace is returned, and read the reasoning tokens back from every run.
+---
+
+# Reasoning and thinking
+
+Modern Anthropic and OpenAI models can spend extra tokens "thinking" before they answer. dendrux exposes this as a small, uniform set of controls that work the same way across both vendors, and it threads the resulting reasoning — token counts and, where the vendor returns it, the summary text — through the same run-result, persistence, streaming, and dashboard rails as everything else.
+
+It is **off by default**. Every existing app keeps its exact behavior until you opt in. Everything below is read from the `dendrux==0.2.0a4` source.
+
+## The controls
+
+The reasoning knobs are constructor arguments on the provider, and every one of them can also be overridden per call via `agent.run(...)` / `agent.stream(...)` kwargs.
+
+| Control | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `thinking` | `bool` | `False` | Master switch. Off → no reasoning request is sent at all. |
+| `effort` | `str \| None` | `None` | Depth: `low` \| `medium` \| `high` \| `xhigh` (`"extra"` is an alias for `xhigh`). |
+| `show_thinking` | `bool` | `True` | When thinking is on: `True` returns the summarized trace; `False` omits it (faster first token). |
+| `thinking_budget` | `int \| None` | `None` | **Anthropic only.** Forces legacy manual thinking with a fixed token budget. `None` → adaptive thinking. |
+
+```python
+from dendrux import Agent
+from dendrux.llm.anthropic import AnthropicProvider
+
+agent = Agent(
+    prompt="…",
+    provider=AnthropicProvider(model="claude-opus-4-8", thinking=True, effort="high"),
+)
+
+# Per-call override — turn thinking up for one hard question, off for the rest.
+await agent.run("Prove this edge case is unreachable.", effort="max")
+```
+
+`effort` is the cross-vendor vocabulary. `max` is Anthropic-only; OpenAI additionally accepts `none` / `minimal`. Each provider normalizes the value to its own API field, so you write one word and it lands correctly on either vendor.
+
+## What each provider does
+
+The switch is uniform; what the vendor *returns* is not. The key split is **token counts everywhere, summary text only where the API offers it**.
+
+| Provider | Mode | Reasoning text? | Notes |
+| --- | --- | --- | --- |
+| `AnthropicProvider` | Adaptive by default; `thinking_budget` switches to legacy manual | Yes — summarized (`show_thinking=True`) | `temperature` is dropped while thinking is on (incompatible). |
+| `OpenAIResponsesProvider` | Reasoning via the Responses API | Yes — summary (`show_thinking=True`) | The provider to use when you want gpt-5 / o-series thinking as text. |
+| `OpenAIProvider` (Chat Completions) | `effort` → `reasoning_effort` | No | Chat Completions returns reasoning **token counts only**, never the trace. |
+
+Adaptive thinking is the only mode current Anthropic models (4.6–4.8 / Fable / Mythos) support; `thinking_budget` exists for older models and fixed-cost workloads. See [Models and providers](/docs/architecture/models) for picking between the two OpenAI providers.
+
+## Reading reasoning back
+
+Reasoning rides the existing token-and-evidence rails, so it shows up everywhere usage already does.
+
+**On the run result.** `RunResult.usage.reasoning_tokens` is the run total (`None` if the provider did not report it):
+
+```python
+result = await agent.run("…")
+print(result.usage.reasoning_tokens)   # e.g. 72
+```
+
+**While streaming.** When the vendor returns a trace, `agent.stream(...)` emits `REASONING_DELTA` events alongside the usual text deltas; the chunk text is on `event.text`.
+
+```python
+from dendrux.types import RunEventType
+
+async for event in agent.stream("…"):
+    if event.type == RunEventType.REASONING_DELTA:
+        print(event.text, end="")
+```
+
+**From the store, after the fact.** Per-call reasoning is on `LLMCall` and the run total is on `RunDetail`:
+
+| Field | Where | Meaning |
+| --- | --- | --- |
+| `LLMCall.reasoning_tokens` | per LLM call | reasoning tokens for that call |
+| `LLMCall.reasoning` | per LLM call | summary text for that call, if returned |
+| `RunDetail.total_reasoning_tokens` | per run | summed across the run |
+
+These are backed by three nullable columns added without breaking the schema — `llm_interactions.reasoning_tokens`, `token_usage.reasoning_tokens`, and `agent_runs.total_reasoning_tokens` (see [State persistence](/docs/architecture/state-persistence)). The [dashboard](/docs/recipes/observability) surfaces the same numbers: a run-header total, a per-call stat, and the summary text in the payload inspector.
+
+## Reasoning tokens and your budget
+
+Reasoning tokens are billed **inside** `output_tokens` — the provider already counts them there. dendrux reports `reasoning_tokens` as an informational breakdown and never adds it on top of the output total, so a [budget](/docs/architecture/budget) is not double-charged. Turning thinking on will raise output-token spend (that is the point); the budget sees that spend through the normal output count, with the reasoning portion broken out so you can see how much of it was thinking.
+
+## Backward compatibility
+
+`thinking` defaults to `False`, the new persistence columns are nullable, and the cross-vendor effort values are opt-in — so an app that never sets these controls sends the exact same requests and stores the exact same rows it did before reasoning existed. A reasoning kwarg meant for one provider (e.g. `thinking` on the Chat Completions provider, which has no trace to return) is accepted and ignored rather than forwarded into a request that would break.

--- a/packages/python/src/dendrux/llm/openai.py
+++ b/packages/python/src/dendrux/llm/openai.py
@@ -269,17 +269,23 @@ class OpenAIProvider(LLMProvider):
         api_messages = self._convert_messages(messages)
         api_tools = self._convert_tools(tools) if tools else openai.NOT_GIVEN
 
-        # Resolve max_tokens: per-call kwargs override constructor default
-        max_tokens = kwargs.pop(
+        # Resolve the output-token cap: per-call kwargs override constructor default.
+        # The official OpenAI endpoint requires `max_completion_tokens` (gpt-5 and
+        # o-series reject `max_tokens` with a 400, and it's deprecated for gpt-4o
+        # too); OpenAI-compatible backends (vLLM, Groq, Ollama, etc.) still expect
+        # `max_tokens`. Gate on base_url, mirroring the prompt_cache_key routing below.
+        max_output_tokens = kwargs.pop(
             "max_completion_tokens",
             kwargs.pop("max_tokens", self._max_tokens),
         )
+        is_openai_endpoint = str(self._client.base_url) == _OPENAI_DEFAULT_BASE_URL
+        token_param = "max_completion_tokens" if is_openai_endpoint else "max_tokens"
 
         api_kwargs: dict[str, Any] = {
             "model": kwargs.pop("model", self._model),
             "messages": api_messages,
             "tools": api_tools,
-            "max_tokens": max_tokens,
+            token_param: max_output_tokens,
         }
 
         # `effort` is the cross-vendor reasoning knob; it overrides
@@ -317,7 +323,7 @@ class OpenAIProvider(LLMProvider):
         # Cache routing — derive key from prefix or run_id.
         # Skip on non-OpenAI base_urls (Groq/Together/vLLM/etc.) since some
         # compatible backends reject unknown OpenAI-specific request fields.
-        if str(self._client.base_url) == _OPENAI_DEFAULT_BASE_URL:
+        if is_openai_endpoint:
             cache_key_source = cache_key_prefix or run_id
             if cache_key_source:
                 api_kwargs["prompt_cache_key"] = f"dendrux:{cache_key_source}"

--- a/packages/python/tests/unit/test_openai_provider.py
+++ b/packages/python/tests/unit/test_openai_provider.py
@@ -507,7 +507,7 @@ class TestComplete:
         assert "unknown_param" not in call_kwargs
 
     async def test_complete_default_max_tokens(self, provider: OpenAIProvider) -> None:
-        """Default max_tokens is 16_000 when not specified."""
+        """Default output cap is 16_000, sent as max_completion_tokens on OpenAI."""
         from unittest.mock import AsyncMock
 
         fake_response = FakeChatCompletion(
@@ -520,7 +520,49 @@ class TestComplete:
         await provider.complete(msgs)
 
         call_kwargs = mock_create.call_args[1]
+        # Official endpoint requires max_completion_tokens (gpt-5/o-series reject
+        # max_tokens with a 400; it is deprecated for gpt-4o too).
+        assert call_kwargs["max_completion_tokens"] == 16_000
+        assert "max_tokens" not in call_kwargs
+
+    async def test_complete_max_completion_tokens_per_call(self, provider: OpenAIProvider) -> None:
+        """Per-call max_tokens / max_completion_tokens override the default cap."""
+        from unittest.mock import AsyncMock
+
+        fake_response = FakeChatCompletion(
+            choices=[FakeChoice(message=FakeMessage(content="ok"))],
+        )
+        mock_create = AsyncMock(return_value=fake_response)
+        provider._client.chat.completions.create = mock_create
+
+        msgs = [Message(role=Role.USER, content="Hi")]
+        await provider.complete(msgs, max_tokens=128)
+
+        call_kwargs = mock_create.call_args[1]
+        assert call_kwargs["max_completion_tokens"] == 128
+        assert "max_tokens" not in call_kwargs
+
+    async def test_complete_compatible_backend_uses_max_tokens(self) -> None:
+        """Compatible backends (custom base_url) keep the legacy max_tokens key."""
+        from unittest.mock import AsyncMock
+
+        p = OpenAIProvider(
+            model="meta-llama/Llama-3-70B",
+            api_key="not-needed",
+            base_url="http://localhost:8000/v1",
+        )
+        fake_response = FakeChatCompletion(
+            choices=[FakeChoice(message=FakeMessage(content="ok"))],
+        )
+        mock_create = AsyncMock(return_value=fake_response)
+        p._client.chat.completions.create = mock_create
+
+        msgs = [Message(role=Role.USER, content="Hi")]
+        await p.complete(msgs)
+
+        call_kwargs = mock_create.call_args[1]
         assert call_kwargs["max_tokens"] == 16_000
+        assert "max_completion_tokens" not in call_kwargs
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- gpt-5/o-series reject max_tokens on Chat Completions (HTTP 400); gate the token-cap key on base_url — max_completion_tokens for OpenAI, max_tokens for compatible backends
- docs: add Models and providers (provider selection + per-API token caps)
- docs: add Reasoning and thinking (controls, per-vendor behavior, surfacing)

Authored-By: Anmol Gautam <anmolgautam2428@gmail.com>
Assisted-By: Claude <noreply@anthropic.com>