### PR TITLE
feat: add total_reasoning_tokens to RunSummary

### DIFF
--- a/packages/python/src/dendrux/store/__init__.py
+++ b/packages/python/src/dendrux/store/__init__.py
@@ -75,6 +75,7 @@ class RunSummary:
     model: str | None
     parent_run_id: str | None
     delegation_level: int
+    total_reasoning_tokens: int = 0
 
 
 @dataclass(frozen=True, slots=True)
@@ -455,6 +456,7 @@ def _run_to_summary(record: Any) -> RunSummary:
         model=record.model,
         parent_run_id=record.parent_run_id,
         delegation_level=record.delegation_level,
+        total_reasoning_tokens=record.total_reasoning_tokens,
     )
 
 

--- a/packages/python/tests/integration/test_run_store.py
+++ b/packages/python/tests/integration/test_run_store.py
@@ -99,6 +99,29 @@ class TestListRuns:
     async def test_empty(self, store) -> None:
         assert await store.list_runs() == []
 
+    async def test_reasoning_tokens_match_detail(self, store, internal_store) -> None:
+        """RunSummary.total_reasoning_tokens mirrors RunDetail's for the same run."""
+        await internal_store.create_run("r1", "Thinker", model="m")
+        await internal_store.finalize_run(
+            "r1",
+            status="success",
+            answer="ok",
+            total_usage=UsageStats(input_tokens=10, output_tokens=20, reasoning_tokens=7),
+        )
+
+        summary = (await store.list_runs())[0]
+        detail = await store.get_run("r1")
+
+        assert summary.total_reasoning_tokens == 7
+        assert summary.total_reasoning_tokens == detail.total_reasoning_tokens
+
+    async def test_reasoning_tokens_default_zero(self, store, internal_store) -> None:
+        """Runs without reasoning report 0, not None."""
+        await internal_store.create_run("r1", "Plain", model="m")
+
+        summary = (await store.list_runs())[0]
+        assert summary.total_reasoning_tokens == 0
+
 
 # ------------------------------------------------------------------
 # metadata_filter — chatbot thread observability + general meta filter


### PR DESCRIPTION
- RunSummary now projects total_reasoning_tokens (was on RunDetail only).
- Populate in _run_to_summary from the existing agent_runs column — no schema change. Lets list views show a per-row reasoning signal without an N+1.
- Tests: summary value matches get_run detail; defaults to 0 (not None).

Authored-By: Anmol Gautam <anmolgautam2428@gmail.com>
Assisted-By: Claude <noreply@anthropic.com>