### PR TITLE
fix: declare httpx as a base dependency

### DIFF
--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -32,6 +32,11 @@ dependencies = [
     "sqlalchemy[asyncio]>=2.0,<3.0",
     "aiosqlite>=0.19,<1.0",
     "alembic>=1.13,<2.0",
+    # httpx is imported at module load on the core import path
+    # (llm/_retry_telemetry.py, pulled in via loops). It must be a hard
+    # dependency so `import dendrux` works without a provider extra — e.g.
+    # a read-only consumer using RunStore + make_read_router.
+    "httpx>=0.27,<1.0",
 ]
 
 [project.optional-dependencies]
@@ -57,7 +62,6 @@ dev = [
     "mypy>=1.10",
     "types-PyYAML>=6.0",
     "python-dotenv>=1.0",
-    "httpx>=0.27",
     "dendrux[otel]",
     "opentelemetry-sdk>=1.30,<2.0",
 ]

--- a/packages/python/tests/unit/test_packaging.py
+++ b/packages/python/tests/unit/test_packaging.py
@@ -1,0 +1,28 @@
+"""Packaging guards — keep the dependency declaration honest.
+
+These read pyproject.toml directly (the source of truth) rather than
+installed metadata, which is stale under editable installs.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+_PYPROJECT = Path(__file__).resolve().parents[2] / "pyproject.toml"
+
+
+def _pyproject() -> dict:
+    return tomllib.loads(_PYPROJECT.read_text())
+
+
+def test_httpx_is_a_base_dependency() -> None:
+    """httpx is imported at module load (llm/_retry_telemetry.py) on the core
+    import path, so it must be a base dependency — not only pulled transitively
+    via a provider extra. Otherwise `import dendrux` fails for installs without
+    a provider SDK (e.g. a read-only RunStore + make_read_router consumer).
+    """
+    base_deps = _pyproject()["project"]["dependencies"]
+    assert any(dep.replace(" ", "").lower().startswith("httpx") for dep in base_deps), (
+        f"httpx must be a base dependency; found base deps: {base_deps}"
+    )


### PR DESCRIPTION
httpx is imported at module load on the core import path (llm/_retry_telemetry.py, via loops), but was only pulled in transitively by the anthropic/openai extras. `import dendrux` crashed for installs without a provider SDK (e.g. a read-only RunStore + make_read_router consumer).

- Add httpx to base dependencies; drop the now-redundant dev entry.
- Guard test asserts httpx stays a base dependency.

Authored-By: Anmol Gautam <anmolgautam2428@gmail.com>
Assisted-By: Claude <noreply@anthropic.com>