### PR TITLE
release: dendrux 0.2.0a7

### DIFF
--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dendrux"
-version = "0.2.0a6"
+version = "0.2.0a7"
 description = "The runtime for agents that act in the real world."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
- httpx is now a base dependency (#27) — `import dendrux` works on lean installs without a provider extra (read-only RunStore consumers).

Authored-By: Anmol Gautam <anmolgautam2428@gmail.com>
Assisted-By: Claude <noreply@anthropic.com>