### PR TITLE
feat(context): ContextBlock + context= for per-run context

### DIFF
--- a/packages/python/examples/28_context_blocks.py
+++ b/packages/python/examples/28_context_blocks.py
@@ -1,0 +1,132 @@
+"""Context blocks demo — per-run context + cross-run cache hits.
+
+Shows the "context out of prompt" pattern: project instructions live in
+``context=`` as a ``stable`` block (not in the agent's ``prompt=``), so they
+fold into the FIRST user message and sit in the cached prefix. Re-supply the
+same stable block every turn and Anthropic reads it from cache on turn 2+.
+
+    Turn 1 → cache WRITE (cache_creation_input_tokens > 0)
+    Turn 2 → cache READ  (cache_read_input_tokens > 0)   ← the win
+
+Dynamic context (retrieved docs for this turn) folds into the CURRENT user
+message instead — volatile tail, re-sent each turn, never cached across turns.
+
+The stable block is deliberately long so the cached prefix crosses Anthropic's
+per-model minimum (2,048 tokens for Sonnet 4.6). Below it, caching is silently
+skipped. OpenAI auto-caches prefixes >= 1,024 tokens but the hit is
+eventually-consistent, so its cache_read may lag by a call or two.
+
+Run with (keys in .env at repo root):
+    python examples/28_context_blocks.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from dotenv import load_dotenv
+
+from dendrux import Agent, ContextBlock
+from dendrux.chat import ChatMessage
+from dendrux.llm.anthropic import AnthropicProvider
+from dendrux.llm.openai import OpenAIProvider
+from dendrux.loops.single import SingleCall
+
+if TYPE_CHECKING:
+    from dendrux.llm.base import LLMProvider
+    from dendrux.types import RunResult
+
+load_dotenv(Path(__file__).resolve().parents[3] / ".env")
+
+
+# A project's runtime instructions — the kind of thing you'd normally be
+# tempted to shove into the agent prompt. It belongs in context= (stable):
+# it's project state, not agent identity. Repeated sections keep it above the
+# cache minimum without needing a real 3k-token document on hand.
+_SECTION = """
+## {n}. Engineering policy section {n}
+
+Testing: every change ships with tests written before the implementation
+(types first, then tests, then code, then refactor). New code carries at
+least 80% line coverage. The full check suite must pass before any commit;
+no exceptions for "trivial" changes, because trivial changes are exactly the
+ones that regress silently. Prefer table-driven tests for pure functions and
+end-to-end tests for anything crossing a process or network boundary.
+
+Code review: all changes land through a branch and a pull request; never push
+to the main branch directly. Reviews check correctness first, then clarity,
+then consistency with the surrounding code — match the file's existing naming,
+comment density, and idioms rather than importing your personal style. A review
+is not a rubber stamp: at least one reviewer must be able to explain what the
+change does and why it is safe.
+
+Architecture: each module depends only on the layers below it. Side effects
+live at the edges; the core is pure and deterministic so it can be tested
+without mocks. Persisted state is written once, atomically, and never rewritten
+in place. Public APIs are typed and documented; private helpers are neither
+unless the logic is non-obvious.
+"""
+
+PROJECT_INSTRUCTIONS = "# Project Orbit — Engineering Handbook\n" + "\n".join(
+    _SECTION.format(n=i) for i in range(1, 13)
+)
+
+
+def _fmt(label: str, r: RunResult) -> str:
+    u = r.usage
+    write = u.cache_creation_input_tokens
+    read = u.cache_read_input_tokens
+    return (
+        f"  {label:<8} input={u.input_tokens:>6}  "
+        f"cache_write={('-' if write is None else write):>6}  "
+        f"cache_read={('-' if read is None else read):>6}"
+    )
+
+
+async def demo(provider: LLMProvider, label: str) -> None:
+    print(f"\n=== {label} ===")
+    agent = Agent(
+        provider=provider,
+        prompt="You are a concise assistant for Project Orbit.",
+        tools=[],
+        loop=SingleCall(),
+    )
+    stable = [
+        ContextBlock(
+            PROJECT_INSTRUCTIONS,
+            kind="project_instructions",
+            placement="stable",
+            source="project:orbit",
+        )
+    ]
+
+    q1 = "In one sentence, what is the testing policy?"
+    r1 = await agent.run(q1, context=stable)
+    print(_fmt("turn 1", r1))
+
+    # Turn 2 — same stable block, prior turn passed as history. The stable head
+    # (project instructions + first turn) is byte-identical → cache read.
+    history = [ChatMessage.user(q1), ChatMessage.assistant(r1.answer)]
+    r2 = await agent.run(
+        "In one sentence, what is the code review policy?",
+        history=history,
+        context=stable,
+    )
+    print(_fmt("turn 2", r2))
+
+    read = r2.usage.cache_read_input_tokens
+    if read:
+        print(f"  ✅ turn 2 read {read} tokens from cache (stable context hit)")
+    else:
+        print("  ⚠️  no cache read on turn 2 (prefix below minimum, or cache cold)")
+
+
+async def main() -> None:
+    await demo(AnthropicProvider(model="claude-sonnet-4-6"), "Anthropic (explicit cache_control)")
+    await demo(OpenAIProvider(model="gpt-4o-mini"), "OpenAI (auto prefix cache)")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/python/src/dendrux/__init__.py
+++ b/packages/python/src/dendrux/__init__.py
@@ -9,6 +9,7 @@ except PackageNotFoundError:  # editable install before metadata exists
     __version__ = "0.0.0+dev"
 
 from dendrux.agent import Agent
+from dendrux.context_blocks import ContextBlock
 from dendrux.errors import (
     InvalidToolResultError,
     PauseStatusMismatchError,
@@ -36,6 +37,7 @@ from dendrux.types import (
 __all__ = [
     "Agent",
     "Budget",
+    "ContextBlock",
     "CreateRunResult",
     "DelegationDepthExceededError",
     "GovernanceEventType",

--- a/packages/python/src/dendrux/agent.py
+++ b/packages/python/src/dendrux/agent.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncEngine
 
     from dendrux.chat import ChatMessage
+    from dendrux.context_blocks import ContextBlock
     from dendrux.guardrails._protocol import Guardrail
     from dendrux.llm.base import LLMProvider
     from dendrux.loops.base import Loop, LoopNotifier
@@ -727,6 +728,7 @@ class Agent:
         user_input: str,
         *,
         history: list[ChatMessage] | None = ...,
+        context: list[ContextBlock] | None = ...,
         tenant_id: str | None = ...,
         metadata: dict[str, Any] | None = ...,
         notifier: LoopNotifier | None = ...,
@@ -742,6 +744,7 @@ class Agent:
         user_input: str,
         *,
         history: list[ChatMessage] | None = ...,
+        context: list[ContextBlock] | None = ...,
         tenant_id: str | None = ...,
         metadata: dict[str, Any] | None = ...,
         notifier: LoopNotifier | None = ...,
@@ -755,6 +758,7 @@ class Agent:
         user_input: str,
         *,
         history: list[ChatMessage] | None = None,
+        context: list[ContextBlock] | None = None,
         tenant_id: str | None = None,
         metadata: dict[str, Any] | None = None,
         notifier: LoopNotifier | None = None,
@@ -779,6 +783,13 @@ class Agent:
                 with ASSISTANT, no consecutive same-role messages, no empty
                 content. Invalid history raises ``ValueError`` before any
                 run is created. ``None`` and ``[]`` mean "no prior context."
+            context: Optional per-run context blocks (``ContextBlock``) folded
+                into the message content — retrieved docs, project
+                instructions/memory, referenced files. ``placement="stable"``
+                blocks fold into the first user message (cached frozen prefix);
+                ``"dynamic"`` (default) fold into the current user message
+                (volatile tail). Read-only, never persisted as forward state;
+                the idempotency hash includes it. See ``dendrux.context_blocks``.
             tenant_id: Optional tenant ID for multi-tenant isolation.
             metadata: Optional developer linking data (thread_id, user_id, etc.).
             notifier: Optional notifier for lifecycle events (e.g. ConsoleNotifier
@@ -858,6 +869,7 @@ class Agent:
             provider=provider,
             user_input=user_input,
             history=history,
+            context=context,
             state_store=store,
             tenant_id=tenant_id,
             metadata=metadata,
@@ -1306,6 +1318,7 @@ class Agent:
         user_input: str,
         *,
         history: list[ChatMessage] | None = ...,
+        context: list[ContextBlock] | None = ...,
         tenant_id: str | None = ...,
         metadata: dict[str, Any] | None = ...,
         notifier: LoopNotifier | None = ...,
@@ -1319,6 +1332,7 @@ class Agent:
         user_input: str,
         *,
         history: list[ChatMessage] | None = ...,
+        context: list[ContextBlock] | None = ...,
         tenant_id: str | None = ...,
         metadata: dict[str, Any] | None = ...,
         notifier: LoopNotifier | None = ...,
@@ -1330,6 +1344,7 @@ class Agent:
         user_input: str,
         *,
         history: list[ChatMessage] | None = None,
+        context: list[ContextBlock] | None = None,
         tenant_id: str | None = None,
         metadata: dict[str, Any] | None = None,
         notifier: LoopNotifier | None = None,
@@ -1419,6 +1434,7 @@ class Agent:
             provider=provider,
             user_input=user_input,
             history=history,
+            context=context,
             state_store_resolver=self._resolve_state_store,
             tenant_id=tenant_id,
             metadata=metadata,

--- a/packages/python/src/dendrux/context_blocks.py
+++ b/packages/python/src/dendrux/context_blocks.py
@@ -1,0 +1,155 @@
+"""Public per-run context surface for agent applications.
+
+Use ``ContextBlock`` to inject per-run context — retrieved documents,
+project instructions/memory, referenced files, surface state — into
+``agent.run()`` / ``agent.stream()`` via ``context=``. Unlike ``history=``
+(prior conversation, dev-owned), context blocks are supplemental material
+for THIS run only: read-only, not persisted as forward state, re-supplied
+each call.
+
+``placement`` is a cache hint, the dev's promise about how the content
+changes turn-to-turn:
+  - ``"stable"``  → byte-identical every turn. Folded into the FIRST user
+                    message so it sits in the frozen, cacheable prefix. If
+                    the dev changes it, they simply lose the cache hit — their
+                    call. Dendrux never reclassifies.
+  - ``"dynamic"`` → per-turn / rebuilt content (default). Folded into the
+                    CURRENT user message at the tail, where growth never
+                    invalidates history's cached prefix. Ephemeral: NOT
+                    persisted into history — the dev stores only raw turns.
+
+Wire shape (context folds into message *content*, not separate messages,
+so the list stays a clean user/assistant alternation on every provider):
+
+    system
+    [user]      "STABLE CONTEXT:\\n…\\n\\nUSER MESSAGE:\\n<first turn>"
+    [assistant] …
+     … history …
+    [user]      "ADDITIONAL CONTEXT:\\n…\\n\\nUSER INPUT:\\n<current input>"
+
+``kind`` / ``source`` / ``metadata`` are opaque: Dendrux carries them for
+audit but never interprets them. The app owns its taxonomy.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from typing import Any, Literal
+
+from dendrux.types import Message, Role
+
+STABLE_HEADER = "STABLE CONTEXT:"
+DYNAMIC_HEADER = "ADDITIONAL CONTEXT:"
+MESSAGE_HEADER = "USER MESSAGE:"
+INPUT_HEADER = "USER INPUT:"
+
+
+@dataclass(frozen=True)
+class ContextBlock:
+    """One labeled block of per-run context passed via ``context=``.
+
+    Frozen so equivalent blocks render byte-identically across turns —
+    required for prompt-cache stability when ``stable`` blocks are re-sent.
+    """
+
+    content: str
+    kind: str = "context"
+    placement: Literal["stable", "dynamic"] = "dynamic"
+    source: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+def validate_context(context: list[ContextBlock] | None) -> None:
+    """Validate context blocks before any side effects.
+
+    Rules:
+      1. Each item must be a ``ContextBlock``.
+      2. Each block must have non-empty content.
+      3. ``placement`` must be ``"stable"`` or ``"dynamic"``.
+
+    ``None`` and ``[]`` are both no-ops. Raises ``TypeError`` / ``ValueError``
+    with an actionable message on the first violation.
+    """
+    if not context:
+        return
+
+    for i, block in enumerate(context):
+        if not isinstance(block, ContextBlock):
+            raise TypeError(f"context[{i}] must be a ContextBlock, got {type(block).__name__}")
+        if not block.content:
+            raise ValueError(f"context[{i}] has empty content")
+        if block.placement not in ("stable", "dynamic"):
+            raise ValueError(
+                f"context[{i}] placement must be 'stable' or 'dynamic', got {block.placement!r}"
+            )
+
+
+def render_band(context: list[ContextBlock] | None, placement: str) -> str:
+    """Render one placement band to text, preserving the caller's order.
+
+    Returns ``""`` when the band is empty. Block contents are joined verbatim
+    by blank lines; no header is added here (see ``fold_context``).
+    """
+    if not context:
+        return ""
+    return "\n\n".join(b.content for b in context if b.placement == placement)
+
+
+def fold_context(
+    history_messages: list[Message],
+    context: list[ContextBlock] | None,
+    user_input: str,
+) -> list[Message] | None:
+    """Fold context blocks into user-message content per the locked format.
+
+    Stable band → prepended to the first user message. Dynamic band →
+    prepended to the current (final) user message alongside ``user_input``.
+    Labels are added only when a band is non-empty, so the no-context path
+    is byte-identical to a plain history + user_input assembly.
+
+    Returns ``None`` only when there is no history AND no context — the
+    single-turn path where the loop builds the ``user_input`` message itself.
+    """
+    validate_context(context)
+    stable = render_band(context, "stable")
+    dynamic = render_band(context, "dynamic")
+
+    if history_messages:
+        first = history_messages[0]
+        if stable:
+            # placement="stable" marks the frozen-prefix boundary for the
+            # provider translator's cross-run cache breakpoint.
+            first_folded = replace(
+                first, content=_fold_first(stable, first.content), placement="stable"
+            )
+        else:
+            first_folded = first
+        current = Message(role=Role.USER, content=_fold_current(dynamic, user_input))
+        return [first_folded, *history_messages[1:], current]
+
+    if not stable and not dynamic:
+        return None
+
+    # Single-turn (no history): render the first-message stable wrapper around
+    # the current-message content so that, once this turn becomes history[0]
+    # next run, its stable head is byte-identical → cross-run cache hit.
+    content = _fold_first(stable, _fold_current(dynamic, user_input))
+    return [
+        Message(
+            role=Role.USER,
+            content=content,
+            placement="stable" if stable else "dynamic",
+        )
+    ]
+
+
+def _fold_first(stable: str, original: str) -> str:
+    if not stable:
+        return original
+    return f"{STABLE_HEADER}\n{stable}\n\n{MESSAGE_HEADER}\n{original}"
+
+
+def _fold_current(dynamic: str, user_input: str) -> str:
+    if not dynamic:
+        return user_input
+    return f"{DYNAMIC_HEADER}\n{dynamic}\n\n{INPUT_HEADER}\n{user_input}"

--- a/packages/python/src/dendrux/llm/anthropic.py
+++ b/packages/python/src/dendrux/llm/anthropic.py
@@ -195,17 +195,20 @@ class AnthropicProvider(LLMProvider):
         self,
         system_prompt: str,
         api_messages: list[dict[str, Any]],
+        *,
+        mark_first: bool = False,
     ) -> tuple[Any, list[dict[str, Any]]]:
-        """Apply cache_control to system block and last message's last block.
+        """Apply cache_control to system block and selected messages.
 
-        The marker on the last message warms the next iteration's cache —
-        the call that writes it pays full creation; the next call reads it.
+        Always marks the last message (warms the next iteration's cache — the
+        call that writes it pays full creation, the next reads it). When
+        ``mark_first`` is set (a stable context head is present), also marks the
+        first user message so the frozen ``tools+system+stable`` prefix is
+        cached across runs.
 
-        Returns ``(system, messages)`` where:
-        - ``system`` is a block list with cache_control, or ``NOT_GIVEN`` when
-          no system prompt was provided.
-        - ``messages`` is a fresh list with the last message deep-copied and
-          augmented with cache_control. The caller's input is never mutated.
+        Returns ``(system, messages)`` where ``system`` is a block list with
+        cache_control (or ``NOT_GIVEN``) and ``messages`` is a fresh list with
+        only the marked messages deep-copied. The caller's input is never mutated.
         """
         marker = self._cache_control_marker()
 
@@ -218,14 +221,22 @@ class AnthropicProvider(LLMProvider):
             return system_blocks, api_messages
 
         new_messages = list(api_messages)
-        last = copy.deepcopy(new_messages[-1])
-        content = last["content"]
+        indices = {len(new_messages) - 1}
+        if mark_first:
+            indices.add(0)
+        for i in indices:
+            marked = copy.deepcopy(new_messages[i])
+            self._mark_last_block(marked, marker)
+            new_messages[i] = marked
+        return system_blocks, new_messages
+
+    @staticmethod
+    def _mark_last_block(message: dict[str, Any], marker: dict[str, Any]) -> None:
+        content = message["content"]
         if isinstance(content, str):
-            last["content"] = [{"type": "text", "text": content, "cache_control": marker}]
+            message["content"] = [{"type": "text", "text": content, "cache_control": marker}]
         elif isinstance(content, list) and content:
             content[-1]["cache_control"] = marker
-        new_messages[-1] = last
-        return system_blocks, new_messages
 
     def _build_api_kwargs(
         self,
@@ -240,7 +251,12 @@ class AnthropicProvider(LLMProvider):
         """
         system_prompt, api_messages = self._convert_messages(messages)
         api_tools = self._convert_tools(tools) if tools else anthropic.NOT_GIVEN
-        system_blocks, cached_messages = self._apply_cache_control(system_prompt, api_messages)
+        # A stable context head (folded into the first user message) gets its own
+        # cross-run cache breakpoint at api_messages[0].
+        has_stable_head = any(m.placement == "stable" for m in messages)
+        system_blocks, cached_messages = self._apply_cache_control(
+            system_prompt, api_messages, mark_first=has_stable_head
+        )
 
         api_kwargs: dict[str, Any] = {
             "model": kwargs.pop("model", self._model),

--- a/packages/python/src/dendrux/loops/react.py
+++ b/packages/python/src/dendrux/loops/react.py
@@ -665,14 +665,9 @@ class ReActLoop(Loop):
                         )
                     if cleaned != msg.content:
                         _in_was_redacted = True
-                        messages[msg_idx] = Message(
-                            role=msg.role,
-                            content=cleaned,
-                            name=msg.name,
-                            tool_calls=msg.tool_calls,
-                            call_id=msg.call_id,
-                            meta=msg.meta,
-                        )
+                        # replace() preserves the origin envelope
+                        # (kind/placement/source) through redaction.
+                        messages[msg_idx] = replace(msg, content=cleaned)
                 if all_in_findings:
                     _in_entities = list({f.entity_type for f in all_in_findings})
                     await _record_governance(

--- a/packages/python/src/dendrux/loops/single.py
+++ b/packages/python/src/dendrux/loops/single.py
@@ -14,6 +14,7 @@ Constraints:
 from __future__ import annotations
 
 import time
+from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 
 from dendrux.guardrails._engine import GuardrailEngine
@@ -179,14 +180,9 @@ class SingleCall(Loop):
                     )
                 if cleaned != msg.content:
                     _in_was_redacted = True
-                    messages[msg_idx] = Message(
-                        role=msg.role,
-                        content=cleaned,
-                        name=msg.name,
-                        tool_calls=msg.tool_calls,
-                        call_id=msg.call_id,
-                        meta=msg.meta,
-                    )
+                    # replace() preserves the origin envelope
+                    # (kind/placement/source) through redaction.
+                    messages[msg_idx] = replace(msg, content=cleaned)
             if all_in_findings:
                 _in_entities = list({f.entity_type for f in all_in_findings})
                 await record_governance(

--- a/packages/python/src/dendrux/runtime/runner.py
+++ b/packages/python/src/dendrux/runtime/runner.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Any, overload
 
 from dendrux._sentinel import _UnsetType
 from dendrux.chat import normalize_chat_history
+from dendrux.context_blocks import ContextBlock, fold_context
 from dendrux.loops._helpers import (
     notify_message,
     notify_run_failed,
@@ -494,6 +495,7 @@ async def run(
     provider: LLMProvider,
     user_input: str,
     history: list[ChatMessage] | None = ...,
+    context: list[ContextBlock] | None = ...,
     strategy: Strategy | None = ...,
     loop: Loop | None = ...,
     state_store: StateStore | None = ...,
@@ -514,6 +516,7 @@ async def run(
     provider: LLMProvider,
     user_input: str,
     history: list[ChatMessage] | None = ...,
+    context: list[ContextBlock] | None = ...,
     strategy: Strategy | None = ...,
     loop: Loop | None = ...,
     state_store: StateStore | None = ...,
@@ -532,6 +535,7 @@ async def run(
     provider: LLMProvider,
     user_input: str,
     history: list[ChatMessage] | None = None,
+    context: list[ContextBlock] | None = None,
     strategy: Strategy | None = None,
     loop: Loop | None = None,
     state_store: StateStore | None = None,
@@ -606,14 +610,7 @@ async def run(
     # do not separately append user_input — same contract as resume).
     # The runner will record the new user_input itself (after the recorder
     # is constructed) so seeded prior turns stay out of react_traces.
-    seeded_history: list[Message] | None
-    if normalized_history:
-        seeded_history = [
-            *normalized_history,
-            Message(role=Role.USER, content=user_input),
-        ]
-    else:
-        seeded_history = None
+    seeded_history = fold_context(normalized_history, context, user_input)
 
     provider_kwargs = dict(kwargs) if kwargs else {}
 
@@ -651,6 +648,7 @@ async def run(
                 user_input,
                 output_type_name=output_type_name,
                 history=normalized_history or None,
+                context=context or None,
             )
 
         create_result = await state_store.create_run(
@@ -1150,6 +1148,7 @@ def run_stream(
     provider: LLMProvider,
     user_input: str,
     history: list[ChatMessage] | None = ...,
+    context: list[ContextBlock] | None = ...,
     strategy: Strategy | None = ...,
     loop: Loop | None = ...,
     state_store: StateStore | None = ...,
@@ -1170,6 +1169,7 @@ def run_stream(
     provider: LLMProvider,
     user_input: str,
     history: list[ChatMessage] | None = ...,
+    context: list[ContextBlock] | None = ...,
     strategy: Strategy | None = ...,
     loop: Loop | None = ...,
     state_store: StateStore | None = ...,
@@ -1188,6 +1188,7 @@ def run_stream(
     provider: LLMProvider,
     user_input: str,
     history: list[ChatMessage] | None = None,
+    context: list[ContextBlock] | None = None,
     strategy: Strategy | None = None,
     loop: Loop | None = None,
     state_store: StateStore | None = None,
@@ -1241,14 +1242,7 @@ def run_stream(
     # (loops use initial_history as-is and do not separately append user_input).
     # The new user_input is recorded by the runner itself inside _generate()
     # so seeded prior turns stay out of react_traces.
-    seeded_history: list[Message] | None
-    if normalized_history:
-        seeded_history = [
-            *normalized_history,
-            Message(role=Role.USER, content=user_input),
-        ]
-    else:
-        seeded_history = None
+    seeded_history = fold_context(normalized_history, context, user_input)
 
     resolved_strategy = strategy or NativeToolCalling()
     resolved_loop = loop or agent.loop or ReActLoop()

--- a/packages/python/src/dendrux/types.py
+++ b/packages/python/src/dendrux/types.py
@@ -70,6 +70,16 @@ class Message:
                     from the corresponding ASSISTANT message.
         name:       Present on TOOL messages only. Cached convenience field for
                     debugging/logging — call_id is the authoritative identity.
+
+    Origin envelope (context-blocks foundation):
+        kind:       Block identity. Defaults from role (TOOL -> "tool_result",
+                    SYSTEM -> "system", else "chat"). Dev-supplied context blocks
+                    set their own opaque kind; Dendrux carries it uninterpreted.
+        placement:  Cache intent, "stable" | "dynamic". Only meaningful for
+                    context-origin messages (drives the stable/dynamic assembly
+                    split); ignored for history/scratchpad, which are positioned
+                    by the assembly order.
+        source:     Optional free-form provenance label (citations/telemetry).
     """
 
     role: Role
@@ -78,8 +88,20 @@ class Message:
     tool_calls: list[ToolCall] | None = None
     call_id: str | None = None
     meta: dict[str, Any] = field(default_factory=dict)
+    kind: str = "chat"
+    placement: str = "dynamic"
+    source: str | None = None
 
     def __post_init__(self) -> None:
+        if self.placement not in ("stable", "dynamic"):
+            raise ValueError(f"placement must be 'stable' or 'dynamic', got {self.placement!r}")
+        # Derive kind from role when left at the generic default. A TOOL message
+        # is always a tool_result; a SYSTEM message is always system context.
+        if self.kind == "chat":
+            if self.role == Role.TOOL:
+                object.__setattr__(self, "kind", "tool_result")
+            elif self.role == Role.SYSTEM:
+                object.__setattr__(self, "kind", "system")
         if self.role == Role.TOOL:
             if not self.name:
                 raise ValueError("TOOL messages require name")
@@ -472,6 +494,14 @@ def _message_to_dict(m: Message) -> dict[str, Any]:
             except (TypeError, ValueError):
                 safe_meta[k] = str(v)
         d["meta"] = safe_meta
+    # Origin envelope — only persist non-default values (kind for TOOL/SYSTEM is
+    # re-derived from role on load, so serialize only when it carries new info).
+    if m.kind not in ("chat", "tool_result", "system"):
+        d["kind"] = m.kind
+    if m.placement != "dynamic":
+        d["placement"] = m.placement
+    if m.source is not None:
+        d["source"] = m.source
     return d
 
 
@@ -486,6 +516,9 @@ def _message_from_dict(d: dict[str, Any]) -> Message:
         tool_calls=tool_calls,
         call_id=d.get("call_id"),
         meta=d.get("meta", {}),
+        kind=d.get("kind", "chat"),
+        placement=d.get("placement", "dynamic"),
+        source=d.get("source"),
     )
 
 
@@ -847,24 +880,37 @@ def compute_idempotency_fingerprint(
     user_input: str,
     output_type_name: str | None = None,
     history: list[Message] | None = None,
+    context: list[Any] | None = None,
 ) -> str:
     """Deterministic SHA-256 fingerprint for idempotency conflict detection.
 
-    Includes agent_name + user_input + output_type + chat history (request
-    identity). Does NOT include provider kwargs (temperature, max_tokens) —
-    those are execution tuning, not request identity.
+    Includes agent_name + user_input + output_type + chat history + per-run
+    context (request identity). Does NOT include provider kwargs (temperature,
+    max_tokens) — those are execution tuning, not request identity.
 
     output_type changes the return shape contract, so two calls with
     different output_types must be treated as different requests.
 
     History is hashed as the canonical list of (role, content) pairs from
     the normalized Message objects — different construction paths producing
-    equivalent normalized history hash identically.
+    equivalent normalized history hash identically. Context blocks are hashed
+    by (kind, placement, source, content) so the same input with different
+    context is treated as a different request.
     """
     data: dict[str, Any] = {"agent_name": agent_name, "user_input": user_input}
     if output_type_name is not None:
         data["output_type"] = output_type_name
     if history:
         data["history"] = [{"role": m.role.value, "content": m.content} for m in history]
+    if context:
+        data["context"] = [
+            {
+                "kind": b.kind,
+                "placement": b.placement,
+                "source": b.source,
+                "content": b.content,
+            }
+            for b in context
+        ]
     payload = json.dumps(data, sort_keys=True, ensure_ascii=True)
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()

--- a/packages/python/tests/unit/test_anthropic.py
+++ b/packages/python/tests/unit/test_anthropic.py
@@ -1269,3 +1269,37 @@ class TestThinkingStream:
         assert not [e for e in collected if e.type == StreamEventType.REASONING_DELTA]
         assert collected[-1].raw.reasoning is None
         assert collected[-1].raw.reasoning_blocks is None
+
+
+class TestStableHeadCacheBreakpoint:
+    """A placement='stable' head message gets its own cross-run cache breakpoint."""
+
+    def _messages(self, *, stable: bool) -> list[Message]:
+        first = Message(
+            role=Role.USER,
+            content="STABLE CONTEXT:\nspec\n\nUSER MESSAGE:\nQ1",
+            placement="stable" if stable else "dynamic",
+        )
+        return [
+            Message(role=Role.SYSTEM, content="sys"),
+            first,
+            Message(role=Role.ASSISTANT, content="A1"),
+            Message(role=Role.USER, content="Q2"),
+        ]
+
+    def test_stable_head_marks_first_message(self, provider: AnthropicProvider) -> None:
+        api_kwargs, _ = provider._build_api_kwargs(self._messages(stable=True), None, {})
+        msgs = api_kwargs["messages"]
+        # First wire message (system extracted) = the stable head → cache_control.
+        assert isinstance(msgs[0]["content"], list)
+        assert msgs[0]["content"][-1].get("cache_control") is not None
+        # Last message keeps its within-run warming marker too.
+        assert msgs[-1]["content"][-1].get("cache_control") is not None
+
+    def test_no_stable_head_leaves_first_unmarked(self, provider: AnthropicProvider) -> None:
+        api_kwargs, _ = provider._build_api_kwargs(self._messages(stable=False), None, {})
+        msgs = api_kwargs["messages"]
+        # No stable head → first message is a plain (unmarked) string.
+        assert isinstance(msgs[0]["content"], str)
+        # Last message still marked (unchanged behavior).
+        assert msgs[-1]["content"][-1].get("cache_control") is not None

--- a/packages/python/tests/unit/test_context_blocks.py
+++ b/packages/python/tests/unit/test_context_blocks.py
@@ -1,0 +1,134 @@
+"""Tests for the public context-block surface (text-folding assembly)."""
+
+import pytest
+
+from dendrux.context_blocks import (
+    ContextBlock,
+    fold_context,
+    render_band,
+    validate_context,
+)
+from dendrux.types import Message, Role
+
+
+def _history() -> list[Message]:
+    return [
+        Message(role=Role.USER, content="Q1"),
+        Message(role=Role.ASSISTANT, content="A1"),
+    ]
+
+
+class TestValidateContext:
+    def test_none_and_empty_are_noops(self) -> None:
+        validate_context(None)
+        validate_context([])
+
+    def test_rejects_non_block(self) -> None:
+        with pytest.raises(TypeError, match="context\\[0\\]"):
+            validate_context(["not a block"])  # type: ignore[list-item]
+
+    def test_rejects_empty_content(self) -> None:
+        with pytest.raises(ValueError, match="empty content"):
+            validate_context([ContextBlock(content="")])
+
+    def test_rejects_bad_placement(self) -> None:
+        with pytest.raises(ValueError, match="placement"):
+            validate_context([ContextBlock(content="x", placement="sticky")])  # type: ignore[arg-type]
+
+
+class TestRenderBand:
+    def test_filters_by_placement_and_preserves_order(self) -> None:
+        ctx = [
+            ContextBlock("instructions", placement="stable"),
+            ContextBlock("doc", placement="dynamic"),
+            ContextBlock("memory", placement="stable"),
+        ]
+        assert render_band(ctx, "stable") == "instructions\n\nmemory"
+        assert render_band(ctx, "dynamic") == "doc"
+
+    def test_empty(self) -> None:
+        assert render_band(None, "stable") == ""
+        assert render_band([], "dynamic") == ""
+
+
+class TestFoldNoHistory:
+    def test_no_history_no_context_returns_none(self) -> None:
+        assert fold_context([], None, "hi") is None
+
+    def test_stable_only(self) -> None:
+        msgs = fold_context([], [ContextBlock("spec", placement="stable")], "hi")
+        assert msgs is not None
+        assert len(msgs) == 1
+        # Uses the first-message wrapper so it stays byte-stable once it
+        # becomes history[0] next run.
+        assert msgs[0].content == "STABLE CONTEXT:\nspec\n\nUSER MESSAGE:\nhi"
+        assert msgs[0].role == Role.USER
+
+    def test_dynamic_only(self) -> None:
+        msgs = fold_context([], [ContextBlock("doc")], "hi")
+        assert msgs is not None
+        assert msgs[0].content == "ADDITIONAL CONTEXT:\ndoc\n\nUSER INPUT:\nhi"
+
+    def test_stable_and_dynamic(self) -> None:
+        ctx = [
+            ContextBlock("spec", placement="stable"),
+            ContextBlock("doc", placement="dynamic"),
+        ]
+        msgs = fold_context([], ctx, "hi")
+        assert msgs is not None
+        assert msgs[0].content == (
+            "STABLE CONTEXT:\nspec\n\nUSER MESSAGE:\nADDITIONAL CONTEXT:\ndoc\n\nUSER INPUT:\nhi"
+        )
+
+
+class TestFoldWithHistory:
+    def test_no_context_is_plain_assembly(self) -> None:
+        # first message unchanged; current message is the raw input.
+        msgs = fold_context(_history(), None, "Q2")
+        assert msgs is not None
+        assert [m.content for m in msgs] == ["Q1", "A1", "Q2"]
+        assert msgs[0].role == Role.USER
+        assert msgs[-1].role == Role.USER
+
+    def test_stable_folds_into_first_message(self) -> None:
+        msgs = fold_context(_history(), [ContextBlock("spec", placement="stable")], "Q2")
+        assert msgs is not None
+        assert msgs[0].content == "STABLE CONTEXT:\nspec\n\nUSER MESSAGE:\nQ1"
+        assert msgs[0].role == Role.USER
+        assert msgs[-1].content == "Q2"  # no dynamic → raw input
+
+    def test_dynamic_folds_into_current_message(self) -> None:
+        msgs = fold_context(_history(), [ContextBlock("doc")], "Q2")
+        assert msgs is not None
+        assert msgs[0].content == "Q1"  # first untouched
+        assert msgs[-1].content == "ADDITIONAL CONTEXT:\ndoc\n\nUSER INPUT:\nQ2"
+
+    def test_stable_and_dynamic_fold_into_respective_messages(self) -> None:
+        ctx = [
+            ContextBlock("spec", placement="stable"),
+            ContextBlock("doc", placement="dynamic"),
+        ]
+        msgs = fold_context(_history(), ctx, "Q2")
+        assert msgs is not None
+        assert msgs[0].content == "STABLE CONTEXT:\nspec\n\nUSER MESSAGE:\nQ1"
+        assert msgs[-1].content == "ADDITIONAL CONTEXT:\ndoc\n\nUSER INPUT:\nQ2"
+
+    def test_within_band_order_preserved(self) -> None:
+        ctx = [
+            ContextBlock("instructions", placement="stable"),
+            ContextBlock("memory", placement="stable"),
+        ]
+        msgs = fold_context(_history(), ctx, "Q2")
+        assert msgs is not None
+        assert msgs[0].content == ("STABLE CONTEXT:\ninstructions\n\nmemory\n\nUSER MESSAGE:\nQ1")
+
+    def test_history_middle_untouched(self) -> None:
+        hist = [
+            Message(role=Role.USER, content="Q1"),
+            Message(role=Role.ASSISTANT, content="A1"),
+            Message(role=Role.USER, content="Q2"),
+            Message(role=Role.ASSISTANT, content="A2"),
+        ]
+        msgs = fold_context(hist, [ContextBlock("spec", placement="stable")], "Q3")
+        assert msgs is not None
+        assert [m.content for m in msgs[1:-1]] == ["A1", "Q2", "A2"]

--- a/packages/python/tests/unit/test_context_blocks_e2e.py
+++ b/packages/python/tests/unit/test_context_blocks_e2e.py
@@ -1,0 +1,188 @@
+"""End-to-end tests for context blocks (agent.run / agent.stream).
+
+Covers text-folding assembly (stable → first user message, dynamic → current
+user message), the no-context path staying byte-identical, streaming, the
+stable-placement tag reaching the provider, and idempotency hashing.
+"""
+
+from __future__ import annotations
+
+from dendrux.agent import Agent
+from dendrux.chat import ChatMessage
+from dendrux.context_blocks import ContextBlock
+from dendrux.llm.mock import MockLLM
+from dendrux.types import (
+    LLMResponse,
+    Message,
+    Role,
+    RunEventType,
+    RunStatus,
+    UsageStats,
+    compute_idempotency_fingerprint,
+)
+
+
+def _resp(text: str) -> LLMResponse:
+    return LLMResponse(text=text, tool_calls=None, usage=UsageStats())
+
+
+def _agent(llm: MockLLM) -> Agent:
+    return Agent(provider=llm, prompt="You are helpful.", tools=[])
+
+
+def _user_messages(llm: MockLLM) -> list[Message]:
+    sent = llm.call_history[0]["messages"]
+    return [m for m in sent if m.role in (Role.USER, Role.ASSISTANT)]
+
+
+class TestFoldingReachesProvider:
+    async def test_stable_folds_into_first_user_message(self) -> None:
+        llm = MockLLM([_resp("Paris")])
+        agent = _agent(llm)
+        result = await agent.run(
+            user_input="Capital of France?",
+            history=[ChatMessage.user("Hello"), ChatMessage.assistant("Hi")],
+            context=[ContextBlock("project spec", kind="spec", placement="stable")],
+        )
+        assert result.status == RunStatus.SUCCESS
+        msgs = _user_messages(llm)
+        assert msgs[0].content == "STABLE CONTEXT:\nproject spec\n\nUSER MESSAGE:\nHello"
+        assert msgs[-1].content == "Capital of France?"
+
+    async def test_dynamic_folds_into_current_message(self) -> None:
+        llm = MockLLM([_resp("ok")])
+        agent = _agent(llm)
+        await agent.run(
+            user_input="Summarize",
+            history=[ChatMessage.user("Hello"), ChatMessage.assistant("Hi")],
+            context=[ContextBlock("retrieved doc", kind="doc")],
+        )
+        msgs = _user_messages(llm)
+        assert msgs[0].content == "Hello"  # first untouched
+        assert msgs[-1].content == "ADDITIONAL CONTEXT:\nretrieved doc\n\nUSER INPUT:\nSummarize"
+
+    async def test_stable_and_dynamic_together(self) -> None:
+        llm = MockLLM([_resp("ok")])
+        agent = _agent(llm)
+        await agent.run(
+            user_input="Q",
+            history=[ChatMessage.user("H"), ChatMessage.assistant("A")],
+            context=[
+                ContextBlock("instructions", placement="stable"),
+                ContextBlock("doc", placement="dynamic"),
+            ],
+        )
+        msgs = _user_messages(llm)
+        assert msgs[0].content == "STABLE CONTEXT:\ninstructions\n\nUSER MESSAGE:\nH"
+        assert msgs[-1].content == "ADDITIONAL CONTEXT:\ndoc\n\nUSER INPUT:\nQ"
+
+    async def test_no_history_single_turn(self) -> None:
+        llm = MockLLM([_resp("ok")])
+        agent = _agent(llm)
+        await agent.run(
+            user_input="Q",
+            context=[ContextBlock("instructions", placement="stable")],
+        )
+        msgs = _user_messages(llm)
+        assert msgs[0].content == "STABLE CONTEXT:\ninstructions\n\nUSER MESSAGE:\nQ"
+
+    async def test_stable_message_is_placement_tagged(self) -> None:
+        llm = MockLLM([_resp("ok")])
+        agent = _agent(llm)
+        await agent.run(
+            user_input="Q",
+            history=[ChatMessage.user("H"), ChatMessage.assistant("A")],
+            context=[ContextBlock("spec", placement="stable")],
+        )
+        user_msgs = [m for m in llm.call_history[0]["messages"] if m.role == Role.USER]
+        assert user_msgs[0].placement == "stable"  # cache-breakpoint signal
+        assert user_msgs[-1].placement == "dynamic"
+
+
+class TestNoContextUnchanged:
+    async def test_no_context_byte_identical_to_plain(self) -> None:
+        llm_ctx = MockLLM([_resp("a")])
+        llm_plain = MockLLM([_resp("b")])
+        hist = [ChatMessage.user("Hello"), ChatMessage.assistant("Hi")]
+        await Agent(provider=llm_ctx, prompt="X", tools=[]).run(
+            user_input="Q", history=hist, context=None
+        )
+        await Agent(provider=llm_plain, prompt="X", tools=[]).run(user_input="Q", history=hist)
+        assert llm_ctx.call_history[0]["messages"] == llm_plain.call_history[0]["messages"]
+
+    async def test_empty_context_is_noop(self) -> None:
+        llm = MockLLM([_resp("ok")])
+        result = await _agent(llm).run(user_input="hi", context=[])
+        assert result.status == RunStatus.SUCCESS
+
+
+class TestStreamAcceptsContext:
+    async def test_stream_folds_context(self) -> None:
+        llm = MockLLM([_resp("Berlin")])
+        agent = Agent(provider=llm, prompt="Geo.", tools=[])
+        events = []
+        async for ev in agent.stream(
+            user_input="Capital?",
+            context=[ContextBlock("hint", placement="stable")],
+        ):
+            events.append(ev)
+        completed = [e for e in events if e.type == RunEventType.RUN_COMPLETED]
+        assert len(completed) == 1
+        msgs = _user_messages(llm)
+        assert msgs[-1].content == "STABLE CONTEXT:\nhint\n\nUSER MESSAGE:\nCapital?"
+
+
+class TestCrossRunStablePrefix:
+    async def test_stable_first_message_byte_stable_across_turns(self) -> None:
+        # Turn 1
+        llm1 = MockLLM([_resp("a1")])
+        await Agent(provider=llm1, prompt="X", tools=[]).run(
+            user_input="Q1", context=[ContextBlock("spec", placement="stable")]
+        )
+        # Turn 2 — Q1 now in history, same stable context re-supplied
+        llm2 = MockLLM([_resp("a2")])
+        await Agent(provider=llm2, prompt="X", tools=[]).run(
+            user_input="Q2",
+            history=[ChatMessage.user("Q1"), ChatMessage.assistant("a1")],
+            context=[ContextBlock("spec", placement="stable")],
+        )
+        first_turn1 = [m for m in llm1.call_history[0]["messages"] if m.role == Role.USER][0]
+        first_turn2 = [m for m in llm2.call_history[0]["messages"] if m.role == Role.USER][0]
+        # The stable head is byte-identical across turns (cacheable prefix).
+        assert (
+            first_turn1.content
+            == first_turn2.content
+            == "STABLE CONTEXT:\nspec\n\nUSER MESSAGE:\nQ1"
+        )
+
+
+class TestIdempotencyWithContext:
+    def _ctx(self, content: str) -> list[ContextBlock]:
+        return [ContextBlock(content, kind="doc", placement="dynamic")]
+
+    def test_same_context_same_hash(self) -> None:
+        h1 = compute_idempotency_fingerprint("a", "in", context=self._ctx("x"))
+        h2 = compute_idempotency_fingerprint("a", "in", context=self._ctx("x"))
+        assert h1 == h2
+
+    def test_different_context_different_hash(self) -> None:
+        h1 = compute_idempotency_fingerprint("a", "in", context=self._ctx("x"))
+        h2 = compute_idempotency_fingerprint("a", "in", context=self._ctx("y"))
+        assert h1 != h2
+
+    def test_context_present_changes_hash(self) -> None:
+        h_none = compute_idempotency_fingerprint("a", "in")
+        h_with = compute_idempotency_fingerprint("a", "in", context=self._ctx("x"))
+        assert h_none != h_with
+
+    def test_none_vs_empty_match(self) -> None:
+        h_none = compute_idempotency_fingerprint("a", "in", context=None)
+        h_empty = compute_idempotency_fingerprint("a", "in", context=[])
+        assert h_none == h_empty
+
+    def test_placement_change_changes_hash(self) -> None:
+        stable = [ContextBlock("x", placement="stable")]
+        dynamic = [ContextBlock("x", placement="dynamic")]
+        h_s = compute_idempotency_fingerprint("a", "in", context=stable)
+        h_d = compute_idempotency_fingerprint("a", "in", context=dynamic)
+        assert h_s != h_d

--- a/packages/python/tests/unit/test_types.py
+++ b/packages/python/tests/unit/test_types.py
@@ -1,5 +1,7 @@
 """Tests for core types."""
 
+from dataclasses import replace
+
 import pytest
 
 from dendrux.types import (
@@ -18,6 +20,8 @@ from dendrux.types import (
     ToolResult,
     ToolTarget,
     UsageStats,
+    _message_from_dict,
+    _message_to_dict,
 )
 
 
@@ -109,6 +113,86 @@ class TestMessageInvariants:
     def test_system_cannot_have_name(self) -> None:
         with pytest.raises(ValueError, match="SYSTEM messages cannot have name"):
             Message(role=Role.SYSTEM, content="prompt", name="sys")
+
+
+class TestMessageOriginEnvelope:
+    """Origin envelope (kind/placement/source) — context-blocks foundation (PR 1)."""
+
+    def test_defaults(self) -> None:
+        msg = Message(role=Role.USER, content="Hi")
+        assert msg.kind == "chat"
+        assert msg.placement == "dynamic"
+        assert msg.source is None
+
+    def test_kind_derived_from_tool_role(self) -> None:
+        msg = Message(role=Role.TOOL, content="{}", name="add", call_id="01ABC")
+        assert msg.kind == "tool_result"
+
+    def test_kind_derived_from_system_role(self) -> None:
+        msg = Message(role=Role.SYSTEM, content="You are helpful")
+        assert msg.kind == "system"
+
+    def test_explicit_kind_preserved(self) -> None:
+        # Dev-supplied context blocks carry an opaque kind Dendrux never interprets.
+        msg = Message(role=Role.USER, content="spec", kind="project_instructions")
+        assert msg.kind == "project_instructions"
+
+    def test_explicit_placement_stable(self) -> None:
+        msg = Message(role=Role.USER, content="spec", placement="stable")
+        assert msg.placement == "stable"
+
+    def test_invalid_placement_rejected(self) -> None:
+        with pytest.raises(ValueError, match="placement"):
+            Message(role=Role.USER, content="x", placement="sticky")
+
+    def test_replace_preserves_envelope(self) -> None:
+        # Guardrail redaction reconstructs via replace() — the envelope must survive.
+        msg = Message(
+            role=Role.USER,
+            content="secret",
+            kind="project_memory",
+            placement="stable",
+            source="project:42",
+        )
+        redacted = replace(msg, content="[REDACTED]")
+        assert redacted.content == "[REDACTED]"
+        assert redacted.kind == "project_memory"
+        assert redacted.placement == "stable"
+        assert redacted.source == "project:42"
+
+    def test_snapshot_roundtrip_context_block(self) -> None:
+        msg = Message(
+            role=Role.USER,
+            content="doc",
+            kind="retrieved_doc",
+            placement="stable",
+            source="https://x",
+        )
+        restored = _message_from_dict(_message_to_dict(msg))
+        assert restored.kind == "retrieved_doc"
+        assert restored.placement == "stable"
+        assert restored.source == "https://x"
+
+    def test_snapshot_roundtrip_tool_result(self) -> None:
+        msg = Message(role=Role.TOOL, content="{}", name="add", call_id="01ABC")
+        restored = _message_from_dict(_message_to_dict(msg))
+        assert restored.kind == "tool_result"
+
+    def test_snapshot_omits_default_envelope(self) -> None:
+        # A plain chat message must not bloat the snapshot with default envelope keys.
+        d = _message_to_dict(Message(role=Role.USER, content="Hi"))
+        assert "kind" not in d
+        assert "placement" not in d
+        assert "source" not in d
+
+    def test_legacy_snapshot_without_envelope(self) -> None:
+        # Snapshots written before PR 1 have no envelope keys — load with defaults,
+        # role-derived kind still applies.
+        restored = _message_from_dict(
+            {"role": "tool", "content": "{}", "name": "add", "call_id": "01ABC"}
+        )
+        assert restored.kind == "tool_result"
+        assert restored.placement == "dynamic"
 
 
 class TestToolCall:


### PR DESCRIPTION
## What

Adds a first public surface for **per-run context**: one new type (`ContextBlock`) and one new argument (`context=`) on `agent.run()` / `agent.stream()`. Lets apps pass retrieved docs, project instructions/memory, referenced files, or surface state without stuffing them into the agent prompt or chat history.

```python
from dendrux import Agent, ContextBlock

await agent.run(user_message, history=chat_history, context=[
    ContextBlock(project.instructions, kind="project_instructions", placement="stable"),
    ContextBlock(retrieved_docs,       kind="retrieved_doc",        placement="dynamic"),
])
```

## The one decision: `placement`

Classify content by **how it changes**, not what it is:

| | placement | folded into | cache |
|---|---|---|---|
| never changes (instructions, pinned spec) | `stable` | the **first** user message | cached across turns |
| changes each turn (docs, this turn's files) | `dynamic` (default) | the **current** user message | volatile tail, never breaks the prefix |

`stable` = the dev's promise "this is byte-identical every turn." If it changes, you just lose that block's cache hit — correctness is never affected. Dendrux never reclassifies.

## How it works

Context blocks fold into user-message **content** as labeled text, so the wire list stays a clean `user/assistant` alternation on every provider (no consecutive same-role messages, no per-provider merge). Anthropic gets an explicit `cache_control` breakpoint on the stable head; OpenAI relies on automatic prefix caching. `kind`/`source`/`metadata` are opaque — carried for audit, never interpreted (the app owns its taxonomy).

Contract mirrors `history=`: per-run, read-only, not persisted as forward state; the idempotency hash includes `context`.

## Validation

Live cross-run cache hit on **both** providers (`examples/28_context_blocks.py`, real APIs) — stable block written turn 1, read from cache turn 2:

| Provider | Turn 1 | Turn 2 |
|---|---|---|
| Anthropic | `cache_write=3381` | **`cache_read=3381`** |
| OpenAI | `input=3153` | **`cache_read=3072`** |

Full suite: **1578 passed**, 90.64% coverage, ruff + mypy clean. New unit + e2e coverage in `test_context_blocks*.py` (incl. an e2e regression test that pins cross-run byte-stability).

## Scope / notes

- Additive only — omit `context=` and today's behavior is byte-identical.
- Internally, `Message` gains an origin envelope (`kind`/`placement`/`source`, `kind` derived from role); guardrail redaction now preserves it via `dataclasses.replace`.
- Deferred (additive follow-up): recording included-block descriptors in the run trace for audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
