### PR TITLE
release: dendrux 0.2.0a8

### DIFF
--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dendrux"
-version = "0.2.0a7"
+version = "0.2.0a8"
 description = "The runtime for agents that act in the real world."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Version bump 0.2.0a7 → 0.2.0a8.

**New since 0.2.0a7:**
- **ContextBlock + `context=`** for per-run context (#29) — pass retrieved docs, project instructions, or memory into a run; `placement="stable"` folds into the cached prefix, `"dynamic"` into the volatile tail. Cross-run cache hit validated on Anthropic + OpenAI.
- Docs recipe for per-run context (#30).

Additive only; no breaking changes. After merge, build + `twine upload` from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)