### PR TITLE
feat(store): correlation_id on llm.completed + id on public LLMCall

### DIFF
--- a/packages/python/src/dendrux/runtime/persistence.py
+++ b/packages/python/src/dendrux/runtime/persistence.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, Any
 
 from dendrux.loops.base import BaseRecorder
 from dendrux.runtime.durability import retry_critical
+from dendrux.types import generate_ulid
 
 if TYPE_CHECKING:
     from dendrux.runtime.state import StateStore
@@ -208,6 +209,11 @@ class PersistenceRecorder(BaseRecorder):
                 "reasoning_tokens": response.usage.reasoning_tokens,
             }
 
+        # Client-minted before either write so the llm_interactions row and
+        # the llm.completed event share one id — a stable 1:1 join key even
+        # if the best-effort interaction save below fails.
+        interaction_id = generate_ulid()
+
         # BEST-EFFORT: llm_interactions (full forensics)
         try:
             await self._store.save_llm_interaction(
@@ -222,6 +228,7 @@ class PersistenceRecorder(BaseRecorder):
                 provider_request=response.provider_request,
                 provider_response=response.provider_response,
                 guardrail_findings=guardrail_findings,
+                interaction_id=interaction_id,
             )
         except Exception:
             logger.warning(
@@ -248,7 +255,8 @@ class PersistenceRecorder(BaseRecorder):
                 exc_info=True,
             )
 
-        # FAIL-CLOSED: run event (lifecycle audit trail)
+        # FAIL-CLOSED: run event (lifecycle audit trail). correlation_id joins
+        # 1:1 to LLMCall.id, mirroring tool.completed -> ToolInvocation.tool_call_id.
         await self._emit_event(
             "llm.completed",
             iteration,
@@ -262,6 +270,7 @@ class PersistenceRecorder(BaseRecorder):
                 "model": response.model or self._model,
                 "has_tool_calls": bool(response.tool_calls),
             },
+            correlation_id=interaction_id,
         )
 
         # BEST-EFFORT: touch progress for sweep

--- a/packages/python/src/dendrux/runtime/state.py
+++ b/packages/python/src/dendrux/runtime/state.py
@@ -338,6 +338,7 @@ class StateStore(Protocol):
         provider_request: dict[str, Any] | None = None,
         provider_response: dict[str, Any] | None = None,
         guardrail_findings: dict[str, Any] | None = None,
+        interaction_id: str | None = None,
     ) -> None: ...
 
     async def get_llm_interactions(
@@ -833,12 +834,13 @@ class SQLAlchemyStateStore:
         provider_request: dict[str, Any] | None = None,
         provider_response: dict[str, Any] | None = None,
         guardrail_findings: dict[str, Any] | None = None,
+        interaction_id: str | None = None,
     ) -> None:
         from dendrux.db.models import LLMInteraction
 
         async with self._session_factory() as session:
             record = LLMInteraction(
-                id=generate_ulid(),
+                id=interaction_id or generate_ulid(),
                 agent_run_id=run_id,
                 iteration_index=iteration_index,
                 model=model,

--- a/packages/python/src/dendrux/store/__init__.py
+++ b/packages/python/src/dendrux/store/__init__.py
@@ -118,8 +118,16 @@ class StoredEvent:
 
 @dataclass(frozen=True, slots=True)
 class LLMCall:
-    """One LLM round-trip recorded during a run."""
+    """One LLM round-trip recorded during a run.
 
+    ``id`` is the interaction's stable identifier. The matching
+    ``llm.completed`` event in ``run_events`` carries it as
+    ``StoredEvent.correlation_id``, so an event stream can be joined 1:1
+    to full LLM payloads — mirroring ``tool.completed.correlation_id`` →
+    ``ToolInvocation.tool_call_id``.
+    """
+
+    id: str
     iteration: int
     provider: str | None
     model: str | None
@@ -498,6 +506,7 @@ def _event_to_stored(record: Any) -> StoredEvent:
 
 def _llm_to_public(record: Any) -> LLMCall:
     return LLMCall(
+        id=record.id,
         iteration=record.iteration_index,
         provider=record.provider,
         model=record.model,

--- a/packages/python/tests/integration/test_run_store.py
+++ b/packages/python/tests/integration/test_run_store.py
@@ -377,6 +377,7 @@ class TestGetLLMCalls:
         assert len(calls) == 1
         call = calls[0]
         assert isinstance(call, LLMCall)
+        assert isinstance(call.id, str) and call.id
         assert call.iteration == 0
         assert call.input_tokens == 100
         assert call.output_tokens == 20
@@ -409,6 +410,31 @@ class TestGetLLMCalls:
 
         page = await store.get_llm_calls("r1", limit=2, offset=2)
         assert [c.iteration for c in page] == [2, 3]
+
+    async def test_id_joins_to_llm_completed_event(self, store, internal_store) -> None:
+        """LLMCall.id round-trips and matches the llm.completed event's
+        correlation_id — the public 1:1 join for LLM payloads."""
+        await internal_store.create_run("r1", "Agent")
+        await internal_store.save_llm_interaction(
+            "r1",
+            iteration_index=0,
+            usage=UsageStats(input_tokens=1, output_tokens=1, total_tokens=2),
+            interaction_id="01JJOINKEYLLMINTERACTION00",
+        )
+        await internal_store.save_run_event(
+            "r1",
+            event_type="llm.completed",
+            sequence_index=0,
+            correlation_id="01JJOINKEYLLMINTERACTION00",
+        )
+
+        call = (await store.get_llm_calls("r1"))[0]
+        events = await store.get_events("r1")
+        completed = [e for e in events if e.event_type == "llm.completed"]
+
+        assert call.id == "01JJOINKEYLLMINTERACTION00"
+        assert len(completed) == 1
+        assert completed[0].correlation_id == call.id
 
 
 # ------------------------------------------------------------------

--- a/packages/python/tests/unit/test_llm_interactions.py
+++ b/packages/python/tests/unit/test_llm_interactions.py
@@ -198,6 +198,22 @@ class TestRecorderLLMInteraction:
         assert rec["provider_request"]["model"] == "claude-sonnet-4-6"
         assert rec["provider_response"]["id"] == "msg_abc"
 
+    async def test_interaction_id_joins_row_to_event(self) -> None:
+        """The recorder mints one id used for both the llm_interactions row
+        and the llm.completed event's correlation_id (1:1 join key)."""
+        store = MockStateStore()
+        obs = PersistenceRecorder(store, "run_1")
+
+        response = LLMResponse(text="hi", usage=UsageStats())
+        await obs.on_llm_call_completed("run_1", response, iteration=1)
+
+        interaction_id = store.llm_interactions[0]["interaction_id"]
+        assert interaction_id, "recorder should pass a minted interaction_id"
+
+        event = store._events["run_1"][0]
+        assert event["event_type"] == "llm.completed"
+        assert event["correlation_id"] == interaction_id
+
     async def test_duration_ms_passed_through(self) -> None:
         """duration_ms kwarg flows from loop → recorder → save_llm_interaction."""
         store = MockStateStore()

--- a/packages/python/tests/unit/test_read_router.py
+++ b/packages/python/tests/unit/test_read_router.py
@@ -532,6 +532,7 @@ class TestLLMCallsEndpoint:
             assert set(body.keys()) == {"items", "limit", "offset"}
             assert len(body["items"]) == 1
             call = body["items"][0]
+            assert isinstance(call["id"], str) and call["id"]
             assert call["iteration"] == 0
             assert call["input_tokens"] == 10
             assert call["cache_read_input_tokens"] == 2

--- a/packages/python/tests/unit/test_reasoning_runtime.py
+++ b/packages/python/tests/unit/test_reasoning_runtime.py
@@ -32,6 +32,7 @@ class TestUsageRollup:
 
 def _fake_llm_record(**over: object) -> SimpleNamespace:
     base = dict(
+        id="llm_1",
         iteration_index=1,
         provider="anthropic",
         model="claude-sonnet-4-6",


### PR DESCRIPTION
## What

Give `llm.completed` events a `correlation_id` and expose `LLMInteraction.id` on the public `LLMCall`, so LLM payloads can be joined 1:1 to the event stream — exactly the way tool payloads already can.

Requested by a team building traces on top of Dendrux's public read surface.

## Why

The tool path is joinable today because **both halves** are present:
- `tool.completed` carries `correlation_id = tool_call.id`
- public `ToolInvocation` exposes `tool_call_id`

The LLM path was missing both:
- `llm.completed` was emitted with `correlation_id = None`
- public `LLMCall` exposed only `iteration`, which is **not unique** — multiple round-trips can share an iteration (provider retries, guardrail re-issues, the SingleCall multi-call loop; `get_llm_interactions` orders by `(iteration_index, id)`), so it's an ambiguous join key.

## How

- Mint one ULID per round-trip in the recorder, **before** either write, and use it for both the `llm_interactions` row (`interaction_id=`) and the `llm.completed` event's `correlation_id`. Minting up front means the id is stable even though the interaction save is best-effort while the event is fail-closed — worst case is a dangling `correlation_id` (no matching row), which is the same contract the tool path already lives with.
- Add `id: str` to the public frozen `LLMCall`; copy `record.id` at the facade boundary. FastAPI serializes the dataclass, so the `/llm-calls` HTTP route surfaces `id` automatically.

## No migration

Both columns already exist: `run_events.correlation_id` (`String(26)`, nullable) and `llm_interactions.id` (`String(26)` PK, ULID). This only starts populating the former for `llm.completed` and surfaces the latter. Forward-only: rows written before this ship keep `correlation_id = NULL` (no backfill needed).

## Scope

Deliberately just the join key — no span/trace abstraction, no parent/child links, no OTel `trace_id` propagation. That unblocks an event-spine-plus-hydrate tracing model without over-building.

## Tests

- Recorder unit test: one minted id flows to both the interaction row and the event `correlation_id`.
- RunStore integration test: `LLMCall.id` round-trips and matches the `llm.completed` event's `correlation_id`.
- Read-router test: `id` present in the `/llm-calls` JSON item.

`make ci` clean locally (ruff, format, mypy, full suite: 1580 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)