### PR TITLE
release: dendrux 0.2.0a9

### DIFF
--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dendrux"
-version = "0.2.0a8"
+version = "0.2.0a9"
 description = "The runtime for agents that act in the real world."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Version bump `0.2.0a8` → `0.2.0a9`.

## Included since 0.2.0a8
- **feat(store): correlation_id on `llm.completed` + `id` on public `LLMCall` (#32)** — LLM payloads can now be joined 1:1 to the `run_events` stream via `llm.completed.correlation_id → LLMCall.id`, symmetric with the existing `tool.completed.correlation_id → ToolInvocation.tool_call_id`. No schema change, forward-only.

Single-line bump to `packages/python/pyproject.toml`; `__version__` derives from package metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)