### PR TITLE
feat(llm): OpenRouter support via OpenAI-compatible transport

### DIFF
--- a/packages/python/examples/29_openrouter.py
+++ b/packages/python/examples/29_openrouter.py
@@ -108,7 +108,12 @@ async def run_via_recipe_string() -> None:
 
 
 async def demo_native_tools_guard(no_tools_model: str) -> None:
-    """Tools + incapable model → explicit error, not silent text."""
+    """Tools + incapable model → explicit error, not silent text.
+
+    Surfacing differs by API, both loud: `agent.run()` re-raises the
+    ValueError; `agent.stream()` reports it in-band as a `run_error` event
+    carrying the same message (streams surface failures as events).
+    """
     print(f"\n== native-tools guard on {no_tools_model} ==")
     agent = Agent(
         provider=OpenRouterProvider(model=no_tools_model),

--- a/packages/python/examples/29_openrouter.py
+++ b/packages/python/examples/29_openrouter.py
@@ -1,0 +1,136 @@
+"""OpenRouter — open-source and premium models through one API.
+
+OpenRouter is OpenAI-Chat-Completions wire-compatible, so `OpenRouterProvider`
+is a thin preset over the same transport as `OpenAIProvider` — streaming,
+native tool calling, usage capture, and the evidence layer all work unchanged.
+On top it adds:
+
+  - `OPENROUTER_API_KEY` resolution + attribution headers
+  - `provider.require_parameters` routing (only upstreams that honor `tools`)
+  - A call-time native-tools guard: passing tools to a model that can't do
+    native function calling raises an explicit error instead of silently
+    returning text that ignores your tools
+  - `list_models()` — the catalog as typed snapshots you filter with plain
+    Python (free vs paid, tools vs not, multimodal vs text-only, price,
+    context length)
+
+This example verifies each of those against the live API and doubles as the
+reference for building model pickers / cost-tier logic on top of Dendrux.
+
+Run with:
+    OPENROUTER_API_KEY=sk-or-... python examples/29_openrouter.py
+    (or put the key in the repo-root .env)
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from dendrux import Agent, tool
+from dendrux.llm.openrouter import OpenRouterProvider
+
+load_dotenv(Path(__file__).resolve().parents[3] / ".env")
+
+MODEL = "deepseek/deepseek-chat"
+
+
+@tool()
+async def add(a: int, b: int) -> int:
+    """Add two numbers together."""
+    return a + b
+
+
+async def explore_catalog() -> str:
+    """list_models(): typed snapshots, filtered with plain Python."""
+    print("== list_models(): catalog exploration ==")
+    async with OpenRouterProvider(model=MODEL) as provider:
+        models = await provider.list_models()
+
+    print(f"Catalog size: {len(models)} models")
+
+    free_tool_models = [m for m in models if m.is_free and m.supports_tools]
+    print(f"Free + native tools: {len(free_tool_models)}")
+    for m in free_tool_models[:3]:
+        print(f"  - {m.id} (ctx {m.context_length})")
+
+    multimodal = [m for m in models if m.is_multimodal]
+    text_only = [m for m in models if not m.is_multimodal]
+    print(f"Multimodal: {len(multimodal)}, text-only: {len(text_only)}")
+
+    cheap_big_ctx = sorted(
+        (
+            m
+            for m in models
+            if m.supports_tools
+            and not m.is_free
+            and (m.context_length or 0) >= 128_000
+            and m.prompt_price is not None
+        ),
+        key=lambda m: m.prompt_price or 0,
+    )
+    print("Cheapest paid tool-capable models with >=128k context:")
+    for m in cheap_big_ctx[:3]:
+        print(f"  - {m.id}  (${(m.prompt_price or 0) * 1e6:.3f}/1M input tokens)")
+
+    # A model without native tools — used below to demo the guard.
+    no_tools = next(m for m in models if not m.supports_tools)
+    print(f"Example model WITHOUT native tools: {no_tools.id}")
+    return no_tools.id
+
+
+async def run_with_tools() -> None:
+    """Native tool calling through OpenRouter — same code path as OpenAI/Anthropic."""
+    print(f"\n== agent.run() with tools on {MODEL} ==")
+    agent = Agent(
+        provider=OpenRouterProvider(model=MODEL),
+        prompt="You are a calculator. Use the add tool to add numbers, then state the result.",
+        tools=[add],
+    )
+    async with agent:
+        result = await agent.run("What is 15 + 27?")
+        print(f"Answer: {result.answer}")
+        print(f"Steps: {result.iteration_count}, Tokens: {result.usage.total_tokens}")
+
+
+async def run_via_recipe_string() -> None:
+    """The `openrouter:model` recipe string — provider built for you."""
+    print("\n== recipe string: Agent(provider='openrouter:<model>') ==")
+    agent = Agent(
+        provider=f"openrouter:{MODEL}",
+        prompt="Answer in one short sentence.",
+    )
+    async with agent:
+        result = await agent.run("What is the capital of France?")
+        print(f"Answer: {result.answer}")
+
+
+async def demo_native_tools_guard(no_tools_model: str) -> None:
+    """Tools + incapable model → explicit error, not silent text."""
+    print(f"\n== native-tools guard on {no_tools_model} ==")
+    agent = Agent(
+        provider=OpenRouterProvider(model=no_tools_model),
+        prompt="You are a calculator.",
+        tools=[add],
+    )
+    async with agent:
+        try:
+            await agent.run("What is 1 + 1?")
+        except ValueError as exc:
+            # The guard raises before any request is sent — the run fails
+            # loudly instead of "succeeding" with an answer that silently
+            # ignored the tools. Without tools, the same model runs fine.
+            print(f"Guard raised as designed:\n  {exc}")
+
+
+async def main() -> None:
+    no_tools_model = await explore_catalog()
+    await run_with_tools()
+    await run_via_recipe_string()
+    await demo_native_tools_guard(no_tools_model)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -42,6 +42,8 @@ dependencies = [
 [project.optional-dependencies]
 anthropic = ["anthropic>=0.40,<1.0"]
 openai = ["openai>=1.50,<3.0"]
+# OpenRouter rides the OpenAI-compatible transport — alias for discoverability.
+openrouter = ["dendrux[openai]"]
 http = ["fastapi>=0.135,<1.0", "uvicorn[standard]"]
 # `db` is kept as an empty alias for backwards compatibility with anyone
 # who already depends on `dendrux[db]`. SQLAlchemy + aiosqlite + alembic

--- a/packages/python/src/dendrux/agent.py
+++ b/packages/python/src/dendrux/agent.py
@@ -120,7 +120,8 @@ def _build_provider_from_spec(spec: str) -> LLMProvider:
     A convenience that mirrors ``database_url``: hand the agent a recipe
     string and it constructs the provider (reading the API key from the
     environment). Supported vendors: ``anthropic``, ``openai``,
-    ``openai-responses``. Pass a provider instance for full configuration.
+    ``openai-responses``, ``openrouter``. Pass a provider instance for full
+    configuration.
     """
     vendor, sep, model = spec.partition(":")
     vendor = vendor.strip().lower()
@@ -142,9 +143,14 @@ def _build_provider_from_spec(spec: str) -> LLMProvider:
         from dendrux.llm.openai_responses import OpenAIResponsesProvider
 
         return OpenAIResponsesProvider(model=model)
+    if vendor == "openrouter":
+        from dendrux.llm.openrouter import OpenRouterProvider
+
+        return OpenRouterProvider(model=model)
     raise ValueError(
         f"Unknown provider vendor {vendor!r}. Supported: anthropic, openai, "
-        "openai-responses. Or pass a provider instance you construct yourself."
+        "openai-responses, openrouter. Or pass a provider instance you "
+        "construct yourself."
     )
 
 

--- a/packages/python/src/dendrux/llm/__init__.py
+++ b/packages/python/src/dendrux/llm/__init__.py
@@ -22,4 +22,8 @@ def __getattr__(name: str) -> type:  # noqa: N807
         from dendrux.llm.openai_responses import OpenAIResponsesProvider
 
         return OpenAIResponsesProvider
+    if name == "OpenRouterProvider":
+        from dendrux.llm.openrouter import OpenRouterProvider
+
+        return OpenRouterProvider
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/packages/python/src/dendrux/llm/__init__.py
+++ b/packages/python/src/dendrux/llm/__init__.py
@@ -26,4 +26,8 @@ def __getattr__(name: str) -> type:  # noqa: N807
         from dendrux.llm.openrouter import OpenRouterProvider
 
         return OpenRouterProvider
+    if name == "OpenRouterModel":
+        from dendrux.llm.openrouter import OpenRouterModel
+
+        return OpenRouterModel
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/packages/python/src/dendrux/llm/_helpers.py
+++ b/packages/python/src/dendrux/llm/_helpers.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 def parse_tool_json_lossy(
-    raw_json: str,
+    raw_json: str | dict[str, Any],
     *,
     provider: str,
     model: str,
@@ -36,7 +36,13 @@ def parse_tool_json_lossy(
 
     Used in streaming paths where a malformed tool call should be logged
     and degraded gracefully rather than crashing the stream.
+
+    Accepts an already-parsed dict as-is: some OpenAI-compatible backends
+    (a few OpenRouter upstreams) return ``arguments`` as an object instead
+    of a JSON string.
     """
+    if isinstance(raw_json, dict):
+        return raw_json
     if not raw_json:
         return {}
     try:
@@ -58,7 +64,7 @@ def parse_tool_json_lossy(
 
 
 def parse_tool_json_strict(
-    raw_json: str,
+    raw_json: str | dict[str, Any],
     *,
     tool_name: str,
     call_id: str,
@@ -67,7 +73,13 @@ def parse_tool_json_strict(
 
     Used in batch (non-streaming) normalization where invalid JSON
     indicates a provider-side issue that should surface immediately.
+
+    Accepts an already-parsed dict as-is: some OpenAI-compatible backends
+    (a few OpenRouter upstreams) return ``arguments`` as an object instead
+    of a JSON string.
     """
+    if isinstance(raw_json, dict):
+        return raw_json
     if not raw_json:
         return {}
     try:

--- a/packages/python/src/dendrux/llm/openai.py
+++ b/packages/python/src/dendrux/llm/openai.py
@@ -183,6 +183,8 @@ class OpenAIProvider(LLMProvider):
         timeout: float = 120.0,
         max_retries: int = 3,
         prompt_cache_retention: Literal["in-memory", "24h"] | None = None,
+        default_headers: dict[str, str] | None = None,
+        extra_body: dict[str, Any] | None = None,
     ) -> None:
         """Create an OpenAI Chat Completions provider.
 
@@ -204,6 +206,13 @@ class OpenAIProvider(LLMProvider):
                 (default) omits the field so OpenAI uses its in-memory default
                 (5–10 min idle, up to 1 h). Set ``"24h"`` for long-running
                 workflows on supported models. Hyphenated literal per the SDK.
+            default_headers: Extra HTTP headers sent with every request
+                (e.g. OpenRouter attribution headers).
+            extra_body: Extra JSON fields merged into every request body —
+                for vendor extensions of the Chat Completions API (e.g.
+                OpenRouter's ``provider`` routing block). A per-call
+                ``extra_body`` kwarg shallow-merges over this, per-call keys
+                winning.
         """
         if api_key is None and not os.getenv("OPENAI_API_KEY"):
             raise ValueError(
@@ -217,6 +226,7 @@ class OpenAIProvider(LLMProvider):
             base_url=base_url,
             http_client=make_telemetry_http_client(httpx.Timeout(timeout, connect=10.0)),
             max_retries=max_retries,
+            default_headers=default_headers,
         )
         self._model = model
         self._max_tokens = max_tokens
@@ -225,6 +235,7 @@ class OpenAIProvider(LLMProvider):
         self._effort = effort
         self._timeout = timeout
         self._prompt_cache_retention = prompt_cache_retention
+        self._extra_body = extra_body
 
     @property
     def model(self) -> str:
@@ -329,6 +340,13 @@ class OpenAIProvider(LLMProvider):
                 api_kwargs["prompt_cache_key"] = f"dendrux:{cache_key_source}"
             if self._prompt_cache_retention is not None:
                 api_kwargs["prompt_cache_retention"] = self._prompt_cache_retention
+
+        # Vendor extensions of the request body (e.g. OpenRouter's `provider`
+        # routing block). Per-call extra_body shallow-merges over the
+        # constructor default, per-call keys winning.
+        call_extra_body = kwargs.pop("extra_body", None)
+        if self._extra_body or call_extra_body:
+            api_kwargs["extra_body"] = {**(self._extra_body or {}), **(call_extra_body or {})}
 
         captured_request = {k: v for k, v in api_kwargs.items() if v is not openai.NOT_GIVEN}
         return api_kwargs, captured_request

--- a/packages/python/src/dendrux/llm/openrouter.py
+++ b/packages/python/src/dendrux/llm/openrouter.py
@@ -1,0 +1,257 @@
+"""OpenRouter provider preset.
+
+OpenRouter is OpenAI-Chat-Completions wire-compatible, so this is a thin
+preset over :class:`OpenAIProvider` — same transport, same conversion layer,
+no extra SDK. It adds:
+
+  - The OpenRouter base URL and ``OPENROUTER_API_KEY`` resolution
+  - Optional attribution headers (``HTTP-Referer`` / ``X-Title``)
+  - ``provider.require_parameters=true`` routing by default, so OpenRouter
+    only routes to upstreams that honor the parameters we send (notably
+    ``tools`` — the same model slug fans out to upstreams with different
+    tool fidelity)
+  - A call-time native-tools capability guard (see below)
+
+**The native-tools guard.** A model that lacks native function calling does
+not error when handed tools — it returns text and silently never calls them.
+That cannot be detected from a response (a capable model choosing not to
+call a tool looks identical), so the guard keys on OpenRouter's per-model
+``supported_parameters`` metadata instead. It fires only when ``tools`` are
+actually passed — tool-free use of any catalog model is unrestricted — and
+raises by default; pass ``require_native_tools=False`` to downgrade to a
+warning. Metadata fetch failures and unknown slugs degrade to a soft
+warning, never a broken run.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+from dendrux.llm.openai import OpenAIProvider
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from dendrux.types import LLMResponse, Message, StreamEvent, ToolDef
+
+logger = logging.getLogger(__name__)
+
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+# Per-process catalog cache keyed by models URL. A failed fetch is cached as
+# None so a flaky metadata endpoint costs at most one request per process —
+# the guard degrades to a warning, it never breaks runs.
+_catalog_cache: dict[str, dict[str, frozenset[str]] | None] = {}
+
+
+async def _fetch_catalog(models_url: str) -> dict[str, frozenset[str]] | None:
+    """Fetch {model_id -> supported_parameters} from OpenRouter, None on failure."""
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(models_url)
+            resp.raise_for_status()
+            payload = resp.json()
+    except Exception as exc:  # noqa: BLE001 — degrade path, never break runs
+        logger.warning(
+            "Could not fetch OpenRouter model catalog from %s (%s). "
+            "Native-tool support cannot be verified; proceeding without the check.",
+            models_url,
+            exc,
+        )
+        return None
+    catalog: dict[str, frozenset[str]] = {}
+    for entry in payload.get("data", []):
+        model_id = entry.get("id")
+        params = entry.get("supported_parameters") or []
+        if isinstance(model_id, str):
+            catalog[model_id] = frozenset(p for p in params if isinstance(p, str))
+    return catalog
+
+
+async def _get_catalog(models_url: str) -> dict[str, frozenset[str]] | None:
+    if models_url not in _catalog_cache:
+        _catalog_cache[models_url] = await _fetch_catalog(models_url)
+    return _catalog_cache[models_url]
+
+
+class OpenRouterProvider(OpenAIProvider):
+    """OpenRouter provider — open-source and premium models via one API.
+
+    Usage:
+        provider = OpenRouterProvider(model="deepseek/deepseek-chat")
+
+        # With attribution (shows up on openrouter.ai rankings)
+        provider = OpenRouterProvider(
+            model="meta-llama/llama-3.3-70b-instruct",
+            app_url="https://myapp.example",
+            app_name="MyApp",
+        )
+
+    Accepts all :class:`OpenAIProvider` keyword arguments (``max_tokens``,
+    ``temperature``, ``timeout``, ``extra_body``, ...) as passthrough.
+    """
+
+    def __init__(
+        self,
+        *,
+        model: str,
+        api_key: str | None = None,
+        app_url: str | None = None,
+        app_name: str | None = None,
+        require_native_tools: bool = True,
+        extra_body: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Create an OpenRouter provider.
+
+        Args:
+            model: OpenRouter model slug (e.g. "deepseek/deepseek-chat",
+                "meta-llama/llama-3.3-70b-instruct").
+            api_key: OpenRouter API key. Defaults to OPENROUTER_API_KEY env var.
+            app_url: Optional attribution URL, sent as ``HTTP-Referer``.
+            app_name: Optional attribution name, sent as ``X-Title``.
+            require_native_tools: When True (default), passing tools to a model
+                whose catalog metadata lacks native tool support raises instead
+                of silently returning text that ignores the tools. Set False to
+                downgrade to a warning.
+            extra_body: Extra JSON fields for the request body. Merged with the
+                default ``provider`` routing block; keys you set win, and your
+                ``provider`` entries merge over ``require_parameters=True``.
+            **kwargs: Passed through to :class:`OpenAIProvider` (max_tokens,
+                temperature, timeout, max_retries, ...).
+        """
+        api_key = api_key or os.getenv("OPENROUTER_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "OpenRouterProvider needs an API key. Pass api_key='sk-or-...' "
+                "or set the OPENROUTER_API_KEY environment variable "
+                "(create one at https://openrouter.ai/keys)."
+            )
+
+        headers: dict[str, str] = {}
+        if app_url:
+            headers["HTTP-Referer"] = app_url
+        if app_name:
+            headers["X-Title"] = app_name
+
+        # Only route to upstreams that honor the parameters we send — without
+        # this, OpenRouter may fall back to an upstream that drops `tools`.
+        user_provider_block = (extra_body or {}).get("provider") or {}
+        merged_extra_body = {
+            **(extra_body or {}),
+            "provider": {"require_parameters": True, **user_provider_block},
+        }
+
+        base_url = kwargs.pop("base_url", OPENROUTER_BASE_URL)
+        super().__init__(
+            model=model,
+            api_key=api_key,
+            base_url=base_url,
+            default_headers=headers or None,
+            extra_body=merged_extra_body,
+            **kwargs,
+        )
+        self._require_native_tools = require_native_tools
+        self._models_url = base_url.rstrip("/") + "/models"
+        self._tools_verified: set[str] = set()
+        self._tool_warnings_emitted: set[tuple[str, str]] = set()
+
+    def __repr__(self) -> str:
+        return f"OpenRouterProvider(model={self._model!r})"
+
+    def _warn_once(self, model: str, reason: str, message: str) -> None:
+        key = (model, reason)
+        if key not in self._tool_warnings_emitted:
+            self._tool_warnings_emitted.add(key)
+            logger.warning(message)
+
+    async def _ensure_native_tool_support(self, model: str) -> None:
+        """Verify the model advertises native tools; raise or warn if not.
+
+        Keys on catalog metadata, never on an observed response — an empty
+        ``tool_calls`` from a capable model (chose not to call) is
+        indistinguishable from one emitted by an incapable model.
+        """
+        if model in self._tools_verified:
+            return
+        catalog = await _get_catalog(self._models_url)
+        if catalog is None:
+            self._warn_once(
+                model,
+                "catalog-unavailable",
+                f"OpenRouter model catalog unavailable — cannot verify that "
+                f"{model!r} supports native tool calling. Proceeding.",
+            )
+            return
+        supported = catalog.get(model)
+        if supported is None:
+            self._warn_once(
+                model,
+                "unknown-model",
+                f"Model {model!r} not found in the OpenRouter catalog — cannot "
+                f"verify native tool support. Proceeding.",
+            )
+            return
+        if "tools" in supported:
+            self._tools_verified.add(model)
+            return
+        message = (
+            f"Model {model!r} (via OpenRouter) does not advertise native tool "
+            f"support (supported_parameters has no 'tools'). It will return "
+            f"plain text and never call your tools. Choose a tool-capable "
+            f"model (see https://openrouter.ai/models?supported_parameters=tools), "
+            f"or run this agent without tools. Pass require_native_tools=False "
+            f"to downgrade this error to a warning."
+        )
+        if self._require_native_tools:
+            raise ValueError(message)
+        self._warn_once(model, "no-native-tools", message)
+
+    async def complete(
+        self,
+        messages: list[Message],
+        tools: list[ToolDef] | None = None,
+        *,
+        output_schema: dict[str, Any] | None = None,
+        run_id: str | None = None,
+        cache_key_prefix: str | None = None,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        """Send messages via OpenRouter; guards native tool support when tools are passed."""
+        if tools:
+            await self._ensure_native_tool_support(kwargs.get("model", self._model))
+        return await super().complete(
+            messages,
+            tools,
+            output_schema=output_schema,
+            run_id=run_id,
+            cache_key_prefix=cache_key_prefix,
+            **kwargs,
+        )
+
+    async def complete_stream(
+        self,
+        messages: list[Message],
+        tools: list[ToolDef] | None = None,
+        *,
+        output_schema: dict[str, Any] | None = None,
+        run_id: str | None = None,
+        cache_key_prefix: str | None = None,
+        **kwargs: Any,
+    ) -> AsyncGenerator[StreamEvent, None]:
+        """Stream via OpenRouter; guards native tool support when tools are passed."""
+        if tools:
+            await self._ensure_native_tool_support(kwargs.get("model", self._model))
+        async for event in super().complete_stream(
+            messages,
+            tools,
+            output_schema=output_schema,
+            run_id=run_id,
+            cache_key_prefix=cache_key_prefix,
+            **kwargs,
+        ):
+            yield event

--- a/packages/python/src/dendrux/llm/openrouter.py
+++ b/packages/python/src/dendrux/llm/openrouter.py
@@ -88,9 +88,12 @@ class OpenRouterModel:
 
 def _parse_price(value: Any) -> float | None:
     try:
-        return float(value)
+        price = float(value)
     except (TypeError, ValueError):
         return None
+    # OpenRouter uses "-1" as a variable-pricing sentinel (e.g. auto-routers);
+    # a negative per-token price is not a price.
+    return price if price >= 0 else None
 
 
 def _parse_modalities(arch: dict[str, Any], key: str, side: int) -> tuple[str, ...]:

--- a/packages/python/src/dendrux/llm/openrouter.py
+++ b/packages/python/src/dendrux/llm/openrouter.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import logging
 import os
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import httpx
@@ -42,39 +43,129 @@ logger = logging.getLogger(__name__)
 
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 
-# Per-process catalog cache keyed by models URL. A failed fetch is cached as
-# None so a flaky metadata endpoint costs at most one request per process —
-# the guard degrades to a warning, it never breaks runs.
-_catalog_cache: dict[str, dict[str, frozenset[str]] | None] = {}
+
+@dataclass(frozen=True, slots=True)
+class OpenRouterModel:
+    """A model in the OpenRouter catalog — an immutable snapshot.
+
+    Rich typed data instead of filter flags: compose any selection with
+    plain Python, e.g.
+    ``[m for m in models if m.is_free and m.supports_tools]``.
+    """
+
+    id: str
+    """OpenRouter model slug, e.g. ``"deepseek/deepseek-chat"``."""
+    name: str
+    """Human-readable name, e.g. ``"DeepSeek V3"``."""
+    context_length: int | None
+    """Maximum context window in tokens, when advertised."""
+    supported_parameters: tuple[str, ...]
+    """Request parameters the model supports (``"tools"``, ``"temperature"``, ...)."""
+    prompt_price: float | None
+    """Input price in USD per token; ``0.0`` for free models, None if unparseable."""
+    completion_price: float | None
+    """Output price in USD per token; ``0.0`` for free models, None if unparseable."""
+    input_modalities: tuple[str, ...]
+    """Accepted input modalities (``"text"``, ``"image"``, ...); empty if unknown."""
+    output_modalities: tuple[str, ...]
+    """Produced output modalities; empty if unknown."""
+
+    @property
+    def supports_tools(self) -> bool:
+        """True when the model advertises native function calling."""
+        return "tools" in self.supported_parameters
+
+    @property
+    def is_free(self) -> bool:
+        """True when both prompt and completion prices are zero."""
+        return self.prompt_price == 0 and self.completion_price == 0
+
+    @property
+    def is_multimodal(self) -> bool:
+        """True when the model accepts any non-text input (image, audio, ...)."""
+        return any(m != "text" for m in self.input_modalities)
 
 
-async def _fetch_catalog(models_url: str) -> dict[str, frozenset[str]] | None:
-    """Fetch {model_id -> supported_parameters} from OpenRouter, None on failure."""
+def _parse_price(value: Any) -> float | None:
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(models_url)
-            resp.raise_for_status()
-            payload = resp.json()
-    except Exception as exc:  # noqa: BLE001 — degrade path, never break runs
-        logger.warning(
-            "Could not fetch OpenRouter model catalog from %s (%s). "
-            "Native-tool support cannot be verified; proceeding without the check.",
-            models_url,
-            exc,
-        )
+        return float(value)
+    except (TypeError, ValueError):
         return None
-    catalog: dict[str, frozenset[str]] = {}
+
+
+def _parse_modalities(arch: dict[str, Any], key: str, side: int) -> tuple[str, ...]:
+    """Read modalities from architecture metadata.
+
+    Prefers the explicit ``input_modalities``/``output_modalities`` lists;
+    falls back to parsing the legacy ``modality`` string
+    (e.g. ``"text+image->text"``, side 0 = input, 1 = output).
+    """
+    explicit = arch.get(key)
+    if isinstance(explicit, list):
+        return tuple(m for m in explicit if isinstance(m, str))
+    modality = arch.get("modality")
+    if isinstance(modality, str) and "->" in modality:
+        parts = modality.split("->")
+        if len(parts) == 2:
+            return tuple(m.strip() for m in parts[side].split("+") if m.strip())
+    return ()
+
+
+def _parse_model_entry(entry: dict[str, Any]) -> OpenRouterModel | None:
+    model_id = entry.get("id")
+    if not isinstance(model_id, str):
+        return None
+    params = entry.get("supported_parameters") or []
+    pricing = entry.get("pricing") or {}
+    arch = entry.get("architecture") or {}
+    context_length = entry.get("context_length")
+    return OpenRouterModel(
+        id=model_id,
+        name=entry.get("name") or model_id,
+        context_length=int(context_length) if isinstance(context_length, int | float) else None,
+        supported_parameters=tuple(p for p in params if isinstance(p, str)),
+        prompt_price=_parse_price(pricing.get("prompt")),
+        completion_price=_parse_price(pricing.get("completion")),
+        input_modalities=_parse_modalities(arch, "input_modalities", 0),
+        output_modalities=_parse_modalities(arch, "output_modalities", 1),
+    )
+
+
+# Per-process catalog cache keyed by models URL — one fetch serves both the
+# native-tools guard and list_models(), so they can never disagree. A failed
+# fetch is cached as None so a flaky metadata endpoint costs at most one
+# request per process on the guard path (which degrades to a warning, never
+# a broken run); list_models() refetches and raises instead.
+_catalog_cache: dict[str, dict[str, OpenRouterModel] | None] = {}
+
+
+async def _fetch_catalog(models_url: str) -> dict[str, OpenRouterModel]:
+    """Fetch {model_id -> OpenRouterModel} from OpenRouter. Raises on failure."""
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        resp = await client.get(models_url)
+        resp.raise_for_status()
+        payload = resp.json()
+    catalog: dict[str, OpenRouterModel] = {}
     for entry in payload.get("data", []):
-        model_id = entry.get("id")
-        params = entry.get("supported_parameters") or []
-        if isinstance(model_id, str):
-            catalog[model_id] = frozenset(p for p in params if isinstance(p, str))
+        model = _parse_model_entry(entry)
+        if model is not None:
+            catalog[model.id] = model
     return catalog
 
 
-async def _get_catalog(models_url: str) -> dict[str, frozenset[str]] | None:
+async def _get_catalog(models_url: str) -> dict[str, OpenRouterModel] | None:
+    """Cached catalog for the guard path — swallows fetch failures as None."""
     if models_url not in _catalog_cache:
-        _catalog_cache[models_url] = await _fetch_catalog(models_url)
+        try:
+            _catalog_cache[models_url] = await _fetch_catalog(models_url)
+        except Exception as exc:  # noqa: BLE001 — degrade path, never break runs
+            logger.warning(
+                "Could not fetch OpenRouter model catalog from %s (%s). "
+                "Native-tool support cannot be verified; proceeding without the check.",
+                models_url,
+                exc,
+            )
+            _catalog_cache[models_url] = None
     return _catalog_cache[models_url]
 
 
@@ -163,6 +254,33 @@ class OpenRouterProvider(OpenAIProvider):
     def __repr__(self) -> str:
         return f"OpenRouterProvider(model={self._model!r})"
 
+    async def list_models(self, *, refresh: bool = False) -> list[OpenRouterModel]:
+        """List the OpenRouter model catalog as typed snapshots.
+
+        Serves from the same per-process cache the native-tools guard uses,
+        so a model picked from this list is guaranteed to pass the guard.
+        Pass ``refresh=True`` to force a refetch — anything beyond
+        process-lifetime caching (TTLs, persistence) is application policy
+        and stays in your hands.
+
+        Unlike the guard (which degrades to a warning), this raises on fetch
+        failure — an explicit listing request deserves a real error, not an
+        empty catalog.
+
+        Usage:
+            models = await provider.list_models()
+            free_tool_models = [m for m in models if m.is_free and m.supports_tools]
+            text_only = [m for m in models if not m.is_multimodal]
+
+        Returns:
+            All catalog models as :class:`OpenRouterModel` snapshots.
+        """
+        catalog = _catalog_cache.get(self._models_url)
+        if refresh or catalog is None:
+            catalog = await _fetch_catalog(self._models_url)
+            _catalog_cache[self._models_url] = catalog
+        return list(catalog.values())
+
     def _warn_once(self, model: str, reason: str, message: str) -> None:
         key = (model, reason)
         if key not in self._tool_warnings_emitted:
@@ -187,8 +305,8 @@ class OpenRouterProvider(OpenAIProvider):
                 f"{model!r} supports native tool calling. Proceeding.",
             )
             return
-        supported = catalog.get(model)
-        if supported is None:
+        entry = catalog.get(model)
+        if entry is None:
             self._warn_once(
                 model,
                 "unknown-model",
@@ -196,7 +314,7 @@ class OpenRouterProvider(OpenAIProvider):
                 f"verify native tool support. Proceeding.",
             )
             return
-        if "tools" in supported:
+        if entry.supports_tools:
             self._tools_verified.add(model)
             return
         message = (

--- a/packages/python/tests/integration/test_openrouter_conformance.py
+++ b/packages/python/tests/integration/test_openrouter_conformance.py
@@ -1,0 +1,62 @@
+"""OpenRouter native-tool conformance smoke test (live, opt-in).
+
+Heterogeneous upstreams can't be proven statically — this is the per-model
+verification: offer a trivial ``echo`` tool, ask the model to call it, and
+assert a parseable ToolCall comes back. Add a slug to MODELS when onboarding
+a model whose tool support you want verified.
+
+Skipped when OPENROUTER_API_KEY is not set — opt-in for CI and local dev.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from dendrux.types import Message, Role, ToolDef
+
+requires_openrouter_key = pytest.mark.skipif(
+    not os.environ.get("OPENROUTER_API_KEY"),
+    reason="OPENROUTER_API_KEY not set",
+)
+
+MODELS = [
+    "deepseek/deepseek-chat",
+]
+
+ECHO_TOOL = ToolDef(
+    name="echo",
+    description="Echo the given text back verbatim.",
+    parameters={
+        "type": "object",
+        "properties": {"text": {"type": "string"}},
+        "required": ["text"],
+    },
+)
+
+
+@requires_openrouter_key
+@pytest.mark.parametrize("model", MODELS)
+async def test_native_tool_call_round_trip(model: str) -> None:
+    """The model returns a parseable native ToolCall for a trivial tool."""
+    from dendrux.llm.openrouter import OpenRouterProvider
+
+    async with OpenRouterProvider(model=model, max_tokens=200) as provider:
+        response = await provider.complete(
+            [
+                Message(
+                    role=Role.SYSTEM,
+                    content="You must call the echo tool. Do not answer in text.",
+                ),
+                Message(role=Role.USER, content="Echo the text 'hello'."),
+            ],
+            [ECHO_TOOL],
+            tool_choice="required",
+        )
+
+    assert response.tool_calls, f"{model} returned no tool call — check upstream routing"
+    call = response.tool_calls[0]
+    assert call.name == "echo"
+    assert isinstance(call.params, dict)
+    assert "hello" in str(call.params.get("text", "")).lower()

--- a/packages/python/tests/integration/test_openrouter_conformance.py
+++ b/packages/python/tests/integration/test_openrouter_conformance.py
@@ -60,3 +60,22 @@ async def test_native_tool_call_round_trip(model: str) -> None:
     assert call.name == "echo"
     assert isinstance(call.params, dict)
     assert "hello" in str(call.params.get("text", "")).lower()
+
+
+@requires_openrouter_key
+async def test_list_models_live() -> None:
+    """The live catalog parses into snapshots with usable filter axes."""
+    from dendrux.llm.openrouter import OpenRouterProvider
+
+    async with OpenRouterProvider(model="deepseek/deepseek-chat") as provider:
+        models = await provider.list_models(refresh=True)
+
+    assert len(models) > 100  # the catalog is large; a tiny list means a parse bug
+    by_id = {m.id: m for m in models}
+    assert "deepseek/deepseek-chat" in by_id
+    assert by_id["deepseek/deepseek-chat"].supports_tools
+    # Every axis is populated somewhere in the catalog
+    assert any(m.is_free for m in models)
+    assert any(not m.is_free for m in models)
+    assert any(m.is_multimodal for m in models)
+    assert any(m.supports_tools for m in models)

--- a/packages/python/tests/unit/test_agent.py
+++ b/packages/python/tests/unit/test_agent.py
@@ -560,6 +560,14 @@ class TestAgentLifecycle:
         await agent.close()
         agent._provider.close.assert_awaited_once()  # type: ignore[union-attr]
 
+    async def test_recipe_string_builds_openrouter_provider(self, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+        from dendrux.llm.openrouter import OpenRouterProvider
+
+        agent = Agent(provider="openrouter:deepseek/deepseek-chat", prompt="Hello.")
+        assert isinstance(agent._provider, OpenRouterProvider)
+        assert agent._provider.model == "deepseek/deepseek-chat"
+
     async def test_invalid_provider_spec_raises(self):
         from dendrux.agent import _build_provider_from_spec
 

--- a/packages/python/tests/unit/test_openrouter_provider.py
+++ b/packages/python/tests/unit/test_openrouter_provider.py
@@ -434,3 +434,13 @@ class TestParseModelEntry:
 
     def test_entry_without_id_skipped(self) -> None:
         assert _parse_model_entry({"name": "no id"}) is None
+
+    def test_negative_price_sentinel_is_none(self) -> None:
+        """OpenRouter reports '-1' for variable pricing (auto-routers)."""
+        model = _parse_model_entry(
+            {"id": "openrouter/auto", "pricing": {"prompt": "-1", "completion": "-1"}}
+        )
+        assert model is not None
+        assert model.prompt_price is None
+        assert model.completion_price is None
+        assert not model.is_free

--- a/packages/python/tests/unit/test_openrouter_provider.py
+++ b/packages/python/tests/unit/test_openrouter_provider.py
@@ -235,6 +235,55 @@ class TestGuardWiring:
                 pass
         create.assert_not_awaited()
 
+    async def test_agent_run_surfaces_guard_as_raised_error(self, catalog_ok: AsyncMock) -> None:
+        """Full stack: agent.run() re-raises the guard's ValueError."""
+        from dendrux import Agent, tool
+
+        @tool()
+        async def add(a: int, b: int) -> int:
+            """Add two numbers."""
+            return a + b
+
+        agent = Agent(
+            provider=_provider(model="tiny/no-tools-model"),
+            prompt="You are a calculator.",
+            tools=[add],
+        )
+        async with agent:
+            with pytest.raises(ValueError, match="does not advertise native tool"):
+                await agent.run("What is 1 + 1?")
+
+    async def test_agent_stream_surfaces_guard_as_run_error_event(
+        self, catalog_ok: AsyncMock
+    ) -> None:
+        """Full stack: agent.stream() surfaces the guard in-band as run_error.
+
+        Streams report failures as events, not exceptions — the guard message
+        must arrive on the run_error event so stream consumers see it.
+        """
+        from dendrux import Agent, tool
+        from dendrux.types import RunEventType
+
+        @tool()
+        async def add(a: int, b: int) -> int:
+            """Add two numbers."""
+            return a + b
+
+        agent = Agent(
+            provider=_provider(model="tiny/no-tools-model"),
+            prompt="You are a calculator.",
+            tools=[add],
+        )
+        events = []
+        async with agent:
+            stream = agent.stream("What is 1 + 1?")
+            async with stream:
+                async for event in stream:
+                    events.append(event)
+        error_events = [e for e in events if e.type == RunEventType.RUN_ERROR]
+        assert len(error_events) == 1
+        assert "does not advertise native tool" in (error_events[0].error or "")
+
     async def test_guard_checks_per_call_model_override(self, catalog_ok: AsyncMock) -> None:
         """A per-call model= override is guarded, not the constructor model."""
         provider = _provider(model="deepseek/deepseek-chat")

--- a/packages/python/tests/unit/test_openrouter_provider.py
+++ b/packages/python/tests/unit/test_openrouter_provider.py
@@ -24,12 +24,40 @@ from dendrux.llm._helpers import (  # noqa: E402
     parse_tool_json_strict,
 )
 from dendrux.llm.openai import OpenAIProvider  # noqa: E402
-from dendrux.llm.openrouter import OPENROUTER_BASE_URL, OpenRouterProvider  # noqa: E402
+from dendrux.llm.openrouter import (  # noqa: E402
+    OPENROUTER_BASE_URL,
+    OpenRouterModel,
+    OpenRouterProvider,
+    _parse_model_entry,
+)
 from dendrux.types import Message, Role, ToolDef  # noqa: E402
 
+
+def _model(
+    model_id: str,
+    params: tuple[str, ...] = (),
+    *,
+    prompt_price: float | None = 0.000002,
+    completion_price: float | None = 0.000006,
+    input_modalities: tuple[str, ...] = ("text",),
+) -> OpenRouterModel:
+    return OpenRouterModel(
+        id=model_id,
+        name=model_id,
+        context_length=131_072,
+        supported_parameters=params,
+        prompt_price=prompt_price,
+        completion_price=completion_price,
+        input_modalities=input_modalities,
+        output_modalities=("text",),
+    )
+
+
 CATALOG = {
-    "deepseek/deepseek-chat": frozenset({"tools", "tool_choice", "temperature"}),
-    "tiny/no-tools-model": frozenset({"temperature", "top_p"}),
+    "deepseek/deepseek-chat": _model(
+        "deepseek/deepseek-chat", ("tools", "tool_choice", "temperature")
+    ),
+    "tiny/no-tools-model": _model("tiny/no-tools-model", ("temperature", "top_p")),
 }
 
 
@@ -133,11 +161,13 @@ class TestNativeToolsGuard:
     async def test_catalog_fetch_failure_proceeds_with_warning(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ) -> None:
-        monkeypatch.setattr(openrouter_mod, "_fetch_catalog", AsyncMock(return_value=None))
+        monkeypatch.setattr(
+            openrouter_mod, "_fetch_catalog", AsyncMock(side_effect=ConnectionError("boom"))
+        )
         provider = _provider()
         with caplog.at_level(logging.WARNING):
             await provider._ensure_native_tool_support("deepseek/deepseek-chat")
-        assert "catalog unavailable" in caplog.text
+        assert "catalog" in caplog.text and "cannot verify" in caplog.text.lower()
 
     async def test_unknown_model_proceeds_with_warning(
         self, catalog_ok: AsyncMock, caplog: pytest.LogCaptureFixture
@@ -159,7 +189,7 @@ class TestNativeToolsGuard:
     async def test_failed_fetch_cached_not_retried_per_call(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        fetch = AsyncMock(return_value=None)
+        fetch = AsyncMock(side_effect=ConnectionError("boom"))
         monkeypatch.setattr(openrouter_mod, "_fetch_catalog", fetch)
         provider = _provider()
         await provider._ensure_native_tool_support("deepseek/deepseek-chat")
@@ -268,3 +298,139 @@ class TestDictArguments:
     def test_strict_still_raises_on_malformed_string(self) -> None:
         with pytest.raises(ValueError, match="invalid JSON"):
             parse_tool_json_strict("{broken", tool_name="add", call_id="c1")
+
+
+# ---------------------------------------------------------------------------
+# list_models() — public catalog listing
+# ---------------------------------------------------------------------------
+class TestListModels:
+    async def test_returns_typed_snapshots(self, catalog_ok: AsyncMock) -> None:
+        provider = _provider()
+        models = await provider.list_models()
+        assert {m.id for m in models} == set(CATALOG)
+        assert all(isinstance(m, OpenRouterModel) for m in models)
+
+    async def test_served_from_shared_cache(self, catalog_ok: AsyncMock) -> None:
+        """list_models and the guard share one fetch — they can never disagree."""
+        provider = _provider()
+        await provider._ensure_native_tool_support("deepseek/deepseek-chat")
+        models = await provider.list_models()
+        assert catalog_ok.await_count == 1
+        picked = next(m for m in models if m.supports_tools)
+        assert picked.id in provider._tools_verified or picked.id == "deepseek/deepseek-chat"
+
+    async def test_refresh_forces_refetch(self, catalog_ok: AsyncMock) -> None:
+        provider = _provider()
+        await provider.list_models()
+        await provider.list_models()
+        assert catalog_ok.await_count == 1
+        await provider.list_models(refresh=True)
+        assert catalog_ok.await_count == 2
+
+    async def test_raises_on_fetch_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Unlike the guard's soft-warn, an explicit listing raises."""
+        monkeypatch.setattr(
+            openrouter_mod, "_fetch_catalog", AsyncMock(side_effect=ConnectionError("boom"))
+        )
+        provider = _provider()
+        with pytest.raises(ConnectionError):
+            await provider.list_models()
+
+    async def test_refetches_after_guard_path_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A cached guard-path failure (None) does not poison list_models."""
+        fetch = AsyncMock(side_effect=[ConnectionError("boom"), CATALOG])
+        monkeypatch.setattr(openrouter_mod, "_fetch_catalog", fetch)
+        provider = _provider()
+        await provider._ensure_native_tool_support("deepseek/deepseek-chat")  # caches None
+        models = await provider.list_models()  # refetches instead of returning nothing
+        assert {m.id for m in models} == set(CATALOG)
+
+    def test_filtering_composes_with_plain_python(self) -> None:
+        models = [
+            _model("free/tools:free", ("tools",), prompt_price=0.0, completion_price=0.0),
+            _model("paid/tools", ("tools",)),
+            _model("free/chat-only:free", (), prompt_price=0.0, completion_price=0.0),
+            _model("paid/vision", ("tools",), input_modalities=("text", "image")),
+        ]
+        assert [m.id for m in models if m.is_free and m.supports_tools] == ["free/tools:free"]
+        assert [m.id for m in models if m.is_multimodal] == ["paid/vision"]
+        assert [m.id for m in models if not m.is_multimodal and not m.is_free] == ["paid/tools"]
+
+
+# ---------------------------------------------------------------------------
+# OpenRouterModel properties
+# ---------------------------------------------------------------------------
+class TestModelProperties:
+    def test_supports_tools(self) -> None:
+        assert _model("a", ("tools",)).supports_tools
+        assert not _model("b", ("temperature",)).supports_tools
+
+    def test_is_free(self) -> None:
+        assert _model("a", prompt_price=0.0, completion_price=0.0).is_free
+        assert not _model("b").is_free
+        # Unknown pricing is not "free"
+        assert not _model("c", prompt_price=None, completion_price=None).is_free
+
+    def test_is_multimodal(self) -> None:
+        assert _model("a", input_modalities=("text", "image")).is_multimodal
+        assert not _model("b", input_modalities=("text",)).is_multimodal
+        # Unknown modalities are not claimed multimodal
+        assert not _model("c", input_modalities=()).is_multimodal
+
+
+# ---------------------------------------------------------------------------
+# Catalog entry parsing
+# ---------------------------------------------------------------------------
+class TestParseModelEntry:
+    def test_full_entry(self) -> None:
+        model = _parse_model_entry(
+            {
+                "id": "deepseek/deepseek-chat",
+                "name": "DeepSeek V3",
+                "context_length": 163840,
+                "pricing": {"prompt": "0.0000002", "completion": "0.0000008"},
+                "supported_parameters": ["tools", "temperature"],
+                "architecture": {
+                    "input_modalities": ["text"],
+                    "output_modalities": ["text"],
+                },
+            }
+        )
+        assert model is not None
+        assert model.name == "DeepSeek V3"
+        assert model.context_length == 163840
+        assert model.prompt_price == pytest.approx(2e-7)
+        assert model.supports_tools and not model.is_free and not model.is_multimodal
+
+    def test_free_variant(self) -> None:
+        model = _parse_model_entry(
+            {
+                "id": "meta-llama/llama-3.3-70b-instruct:free",
+                "pricing": {"prompt": "0", "completion": "0"},
+                "supported_parameters": [],
+            }
+        )
+        assert model is not None
+        assert model.is_free
+        assert model.name == "meta-llama/llama-3.3-70b-instruct:free"  # falls back to id
+
+    def test_legacy_modality_string_fallback(self) -> None:
+        model = _parse_model_entry(
+            {"id": "x/vision", "architecture": {"modality": "text+image->text"}}
+        )
+        assert model is not None
+        assert model.input_modalities == ("text", "image")
+        assert model.output_modalities == ("text",)
+        assert model.is_multimodal
+
+    def test_missing_fields_degrade_to_none_or_empty(self) -> None:
+        model = _parse_model_entry({"id": "bare/model"})
+        assert model is not None
+        assert model.context_length is None
+        assert model.prompt_price is None
+        assert model.input_modalities == ()
+
+    def test_entry_without_id_skipped(self) -> None:
+        assert _parse_model_entry({"name": "no id"}) is None

--- a/packages/python/tests/unit/test_openrouter_provider.py
+++ b/packages/python/tests/unit/test_openrouter_provider.py
@@ -1,0 +1,270 @@
+"""Tests for the OpenRouter provider preset.
+
+Covers the native-tools capability guard (the crux — an incapable model
+returns text and silently never calls tools, which is indistinguishable
+from a capable model choosing not to call one), the extra_body/routing
+merge, attribution headers, and the dict-typed-arguments parser hardening.
+
+All unit tests are fully mocked — no network.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+openai = pytest.importorskip("openai", reason="openai extra not installed")
+
+import dendrux.llm.openrouter as openrouter_mod  # noqa: E402
+from dendrux.llm._helpers import (  # noqa: E402
+    parse_tool_json_lossy,
+    parse_tool_json_strict,
+)
+from dendrux.llm.openai import OpenAIProvider  # noqa: E402
+from dendrux.llm.openrouter import OPENROUTER_BASE_URL, OpenRouterProvider  # noqa: E402
+from dendrux.types import Message, Role, ToolDef  # noqa: E402
+
+CATALOG = {
+    "deepseek/deepseek-chat": frozenset({"tools", "tool_choice", "temperature"}),
+    "tiny/no-tools-model": frozenset({"temperature", "top_p"}),
+}
+
+
+@pytest.fixture(autouse=True)
+def _clear_catalog_cache() -> None:
+    openrouter_mod._catalog_cache.clear()
+
+
+@pytest.fixture
+def catalog_ok(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    fetch = AsyncMock(return_value=CATALOG)
+    monkeypatch.setattr(openrouter_mod, "_fetch_catalog", fetch)
+    return fetch
+
+
+def _provider(**kwargs: Any) -> OpenRouterProvider:
+    kwargs.setdefault("model", "deepseek/deepseek-chat")
+    kwargs.setdefault("api_key", "sk-or-test")
+    return OpenRouterProvider(**kwargs)
+
+
+def _tools() -> list[ToolDef]:
+    return [ToolDef(name="echo", description="Echo", parameters={"type": "object"})]
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+class TestConstruction:
+    def test_missing_api_key_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="OPENROUTER_API_KEY"):
+            OpenRouterProvider(model="deepseek/deepseek-chat")
+
+    def test_api_key_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-env")
+        provider = OpenRouterProvider(model="deepseek/deepseek-chat")
+        assert provider.model == "deepseek/deepseek-chat"
+
+    def test_base_url_is_openrouter(self) -> None:
+        provider = _provider()
+        assert str(provider._client.base_url).rstrip("/") == OPENROUTER_BASE_URL
+
+    def test_attribution_headers(self) -> None:
+        provider = _provider(app_url="https://myapp.example", app_name="MyApp")
+        headers = provider._client.default_headers
+        assert headers["HTTP-Referer"] == "https://myapp.example"
+        assert headers["X-Title"] == "MyApp"
+
+    def test_require_parameters_routing_default(self) -> None:
+        provider = _provider()
+        assert provider._extra_body == {"provider": {"require_parameters": True}}
+
+    def test_user_provider_block_merges_over_default(self) -> None:
+        provider = _provider(extra_body={"provider": {"order": ["deepseek"]}})
+        assert provider._extra_body == {
+            "provider": {"require_parameters": True, "order": ["deepseek"]}
+        }
+
+    def test_user_extra_body_keys_preserved(self) -> None:
+        provider = _provider(extra_body={"transforms": ["middle-out"]})
+        assert provider._extra_body is not None
+        assert provider._extra_body["transforms"] == ["middle-out"]
+        assert provider._extra_body["provider"] == {"require_parameters": True}
+
+    def test_repr(self) -> None:
+        assert repr(_provider()) == "OpenRouterProvider(model='deepseek/deepseek-chat')"
+
+
+# ---------------------------------------------------------------------------
+# Native-tools capability guard
+# ---------------------------------------------------------------------------
+class TestNativeToolsGuard:
+    async def test_capable_model_passes(self, catalog_ok: AsyncMock) -> None:
+        provider = _provider()
+        await provider._ensure_native_tool_support("deepseek/deepseek-chat")
+        assert "deepseek/deepseek-chat" in provider._tools_verified
+
+    async def test_incapable_model_raises_by_default(self, catalog_ok: AsyncMock) -> None:
+        provider = _provider(model="tiny/no-tools-model")
+        with pytest.raises(ValueError, match="does not advertise native tool"):
+            await provider._ensure_native_tool_support("tiny/no-tools-model")
+
+    async def test_incapable_model_warns_when_opted_out(
+        self, catalog_ok: AsyncMock, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        provider = _provider(model="tiny/no-tools-model", require_native_tools=False)
+        with caplog.at_level(logging.WARNING):
+            await provider._ensure_native_tool_support("tiny/no-tools-model")
+        assert "does not advertise native tool" in caplog.text
+
+    async def test_warning_emitted_once_per_model(
+        self, catalog_ok: AsyncMock, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        provider = _provider(model="tiny/no-tools-model", require_native_tools=False)
+        with caplog.at_level(logging.WARNING):
+            await provider._ensure_native_tool_support("tiny/no-tools-model")
+            await provider._ensure_native_tool_support("tiny/no-tools-model")
+        assert caplog.text.count("does not advertise native tool") == 1
+
+    async def test_catalog_fetch_failure_proceeds_with_warning(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        monkeypatch.setattr(openrouter_mod, "_fetch_catalog", AsyncMock(return_value=None))
+        provider = _provider()
+        with caplog.at_level(logging.WARNING):
+            await provider._ensure_native_tool_support("deepseek/deepseek-chat")
+        assert "catalog unavailable" in caplog.text
+
+    async def test_unknown_model_proceeds_with_warning(
+        self, catalog_ok: AsyncMock, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        provider = _provider(model="brand/new-model")
+        with caplog.at_level(logging.WARNING):
+            await provider._ensure_native_tool_support("brand/new-model")
+        assert "not found in the OpenRouter catalog" in caplog.text
+
+    async def test_catalog_fetched_once_per_process(self, catalog_ok: AsyncMock) -> None:
+        provider = _provider()
+        await provider._ensure_native_tool_support("deepseek/deepseek-chat")
+        await provider._ensure_native_tool_support("deepseek/deepseek-chat")
+        # Second provider instance shares the process-level cache.
+        other = _provider()
+        await other._ensure_native_tool_support("deepseek/deepseek-chat")
+        assert catalog_ok.await_count == 1
+
+    async def test_failed_fetch_cached_not_retried_per_call(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fetch = AsyncMock(return_value=None)
+        monkeypatch.setattr(openrouter_mod, "_fetch_catalog", fetch)
+        provider = _provider()
+        await provider._ensure_native_tool_support("deepseek/deepseek-chat")
+        await provider._ensure_native_tool_support("deepseek/deepseek-chat")
+        assert fetch.await_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Guard wiring in complete() / complete_stream()
+# ---------------------------------------------------------------------------
+class TestGuardWiring:
+    async def test_complete_with_tools_raises_before_request(
+        self, catalog_ok: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        provider = _provider(model="tiny/no-tools-model")
+        create = AsyncMock()
+        monkeypatch.setattr(provider._client.chat.completions, "create", create)
+        with pytest.raises(ValueError, match="does not advertise native tool"):
+            await provider.complete([Message(role=Role.USER, content="hi")], _tools())
+        create.assert_not_awaited()
+
+    async def test_complete_without_tools_skips_guard(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fetch = AsyncMock(return_value=CATALOG)
+        monkeypatch.setattr(openrouter_mod, "_fetch_catalog", fetch)
+        sentinel = object()
+        monkeypatch.setattr(OpenAIProvider, "complete", AsyncMock(return_value=sentinel))
+        provider = _provider(model="tiny/no-tools-model")  # incapable, but no tools passed
+        result = await provider.complete([Message(role=Role.USER, content="hi")])
+        assert result is sentinel
+        fetch.assert_not_awaited()
+
+    async def test_complete_stream_with_tools_raises_before_request(
+        self, catalog_ok: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        provider = _provider(model="tiny/no-tools-model")
+        create = AsyncMock()
+        monkeypatch.setattr(provider._client.chat.completions, "create", create)
+        with pytest.raises(ValueError, match="does not advertise native tool"):
+            stream = provider.complete_stream([Message(role=Role.USER, content="hi")], _tools())
+            async for _ in stream:
+                pass
+        create.assert_not_awaited()
+
+    async def test_guard_checks_per_call_model_override(self, catalog_ok: AsyncMock) -> None:
+        """A per-call model= override is guarded, not the constructor model."""
+        provider = _provider(model="deepseek/deepseek-chat")
+        with pytest.raises(ValueError, match="does not advertise native tool"):
+            await provider.complete(
+                [Message(role=Role.USER, content="hi")],
+                _tools(),
+                model="tiny/no-tools-model",
+            )
+
+
+# ---------------------------------------------------------------------------
+# extra_body flows into the request kwargs (OpenAIProvider passthrough)
+# ---------------------------------------------------------------------------
+class TestExtraBodyPassthrough:
+    def test_constructor_extra_body_in_api_kwargs(self) -> None:
+        provider = _provider()
+        api_kwargs, captured = provider._build_api_kwargs(
+            [Message(role=Role.USER, content="hi")], None, {}
+        )
+        assert api_kwargs["extra_body"] == {"provider": {"require_parameters": True}}
+        assert captured["extra_body"] == api_kwargs["extra_body"]
+
+    def test_per_call_extra_body_merges_over_constructor(self) -> None:
+        provider = _provider()
+        api_kwargs, _ = provider._build_api_kwargs(
+            [Message(role=Role.USER, content="hi")],
+            None,
+            {"extra_body": {"transforms": ["middle-out"]}},
+        )
+        assert api_kwargs["extra_body"] == {
+            "provider": {"require_parameters": True},
+            "transforms": ["middle-out"],
+        }
+
+    def test_plain_openai_provider_omits_extra_body_by_default(self) -> None:
+        provider = OpenAIProvider(model="gpt-4o", api_key="test-key")
+        api_kwargs, _ = provider._build_api_kwargs(
+            [Message(role=Role.USER, content="hi")], None, {}
+        )
+        assert "extra_body" not in api_kwargs
+
+
+# ---------------------------------------------------------------------------
+# Parser hardening — dict-typed `arguments` from some upstreams
+# ---------------------------------------------------------------------------
+class TestDictArguments:
+    def test_strict_accepts_dict(self) -> None:
+        params = parse_tool_json_strict({"a": 1}, tool_name="add", call_id="c1")
+        assert params == {"a": 1}
+
+    def test_lossy_accepts_dict(self) -> None:
+        params = parse_tool_json_lossy(
+            {"a": 1}, provider="openrouter", model="m", tool_name="add", call_id="c1"
+        )
+        assert params == {"a": 1}
+
+    def test_strict_still_parses_strings(self) -> None:
+        assert parse_tool_json_strict('{"a": 1}', tool_name="add", call_id="c1") == {"a": 1}
+
+    def test_strict_still_raises_on_malformed_string(self) -> None:
+        with pytest.raises(ValueError, match="invalid JSON"):
+            parse_tool_json_strict("{broken", tool_name="add", call_id="c1")


### PR DESCRIPTION
## What

OpenRouter compatibility — open-source and premium models through one API — **without** the OpenRouter SDK. OpenRouter is OpenAI-Chat-Completions wire-compatible, so this ships a thin `OpenRouterProvider(OpenAIProvider)` preset over the existing transport. Approach doc: `owner-docs/impl-openrouter.md`.

## Changes

- **`llm/openrouter.py`** — `OpenRouterProvider` preset: base URL, `OPENROUTER_API_KEY` resolution, attribution headers (`HTTP-Referer`/`X-Title`), and default `provider.require_parameters=true` routing so OpenRouter only routes to upstreams that honor `tools`.
- **Native-tools capability guard (the crux):** an incapable model returns text and *silently never calls tools* — indistinguishable from a capable model choosing not to. The guard keys on OpenRouter's `supported_parameters` catalog metadata, fires only when tools are actually passed (tool-free use is unrestricted, no construction-time block), and **errors by default**; `require_native_tools=False` downgrades to a warning. Catalog fetch failure / unknown slug → soft warning, never a broken run. Lazy fetch, cached per process.
- **`llm/openai.py`** — `default_headers` + `extra_body` passthrough (per-call `extra_body` shallow-merges over constructor).
- **`llm/_helpers.py`** — parsers accept dict-typed `arguments` (some upstreams return pre-parsed objects; previously an uncaught `TypeError`).
- **`agent.py`** — `openrouter:model` recipe alias (`Agent(provider="openrouter:deepseek/deepseek-chat")`).
- **`pyproject.toml`** — `openrouter` extra as an alias of `openai`. No new dependency.

## Deferred

The prompt-based tool-call shim for non-native-tool models (`owner-docs/impl-tool-call-shim.md`) — now an *extension* reached via `require_native_tools=False`, no longer a blocker.

## Testing

- 28 new unit tests (guard behaviors, wiring in `complete`/`complete_stream`, per-call model override, extra_body merge, parser hardening, recipe alias) — fully mocked, no network. Full suite: **1608 passed, 248 skipped**; ruff + mypy strict clean.
- Live conformance test (opt-in, gated on `OPENROUTER_API_KEY`): `deepseek/deepseek-chat` round-tripped a real native tool call — **passed locally**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)