### PR TITLE
release: dendrux 0.2.0a10

### DIFF
--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dendrux"
-version = "0.2.0a9"
+version = "0.2.0a10"
 description = "The runtime for agents that act in the real world."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Version bump `0.2.0a9` → `0.2.0a10` for PyPI.

Ships:
- feat(llm): OpenRouter support via OpenAI-compatible transport (#34) — `OpenRouterProvider`, native-tools capability guard, `list_models()` catalog snapshots, `openrouter:` recipe alias, `openrouter` extra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)