### PR TITLE
fix(ci): pin ruff to 0.15.17 for deterministic format checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.6
+    rev: v0.15.17
     hooks:
       - id: ruff
         args: [--fix, --config, packages/python/pyproject.toml]

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -60,7 +60,7 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
     "pytest-cov>=5.0",
-    "ruff>=0.8",
+    "ruff==0.15.17",
     "mypy>=1.10",
     "types-PyYAML>=6.0",
     "python-dotenv>=1.0",


### PR DESCRIPTION
## Problem

`ruff format --check .` was failing CI on **every** PR — including docs-only ones (#37) — on unchanged code.

**Root cause:** the dev dependency pinned `ruff>=0.8` with no upper bound, and CI installs fresh (`pip install -e ".[dev,all]"`), so it silently picked up a ruff newer than developers run locally. That newer ruff formats Python code blocks embedded in Markdown, and wants to reformat `README.md`'s intentionally-aligned example comments (`provider=provider,   # Required` → `provider=provider,  # Required`) plus blank-line spacing. Nothing in the actual source changed — the toolchain drifted.

Three tools were on three different ruff versions: pre-commit `v0.8.6`, CI latest, local `0.15.17`.

## Fix

Pin one version everywhere. `0.15.17` is verified to report the entire tree clean (`ruff check .` and `ruff format --check .` both pass locally, README included).

- `pyproject.toml` dev: `ruff>=0.8` → `ruff==0.15.17`
- `.pre-commit-config.yaml`: `rev: v0.8.6` → `rev: v0.15.17`

Formatters should be pinned exactly — their output changes across releases, so an unbounded range makes CI non-deterministic by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)