### PR TITLE
feat(llm): make OpenRouterProvider model optional for discovery

### DIFF
--- a/docs/recipes/openrouter.mdx
+++ b/docs/recipes/openrouter.mdx
@@ -53,10 +53,10 @@ dendrux also sends OpenRouter's `provider.require_parameters` routing flag by de
 
 ## `list_models()` — build on the catalog
 
-The catalog is queryable as typed, immutable snapshots. There are no filter kwargs — every field is a filter axis, composed with plain Python:
+The catalog is queryable as typed, immutable snapshots — no model needed, since discovery isn't tied to a chosen one. There are no filter kwargs either; every field is a filter axis, composed with plain Python:
 
 ```python
-async with OpenRouterProvider(model="deepseek/deepseek-chat") as provider:
+async with OpenRouterProvider() as provider:   # discovery-only: no model required
     models = await provider.list_models()
 
 free_tool_models = [m for m in models if m.is_free and m.supports_tools]

--- a/packages/python/src/dendrux/llm/openrouter.py
+++ b/packages/python/src/dendrux/llm/openrouter.py
@@ -192,7 +192,7 @@ class OpenRouterProvider(OpenAIProvider):
     def __init__(
         self,
         *,
-        model: str,
+        model: str | None = None,
         api_key: str | None = None,
         app_url: str | None = None,
         app_name: str | None = None,
@@ -204,7 +204,10 @@ class OpenRouterProvider(OpenAIProvider):
 
         Args:
             model: OpenRouter model slug (e.g. "deepseek/deepseek-chat",
-                "meta-llama/llama-3.3-70b-instruct").
+                "meta-llama/llama-3.3-70b-instruct"). Optional — omit it to
+                build a discovery-only provider for ``list_models()``. Running
+                inference then requires a model passed per call, or ``complete``/
+                ``complete_stream`` raise.
             api_key: OpenRouter API key. Defaults to OPENROUTER_API_KEY env var.
             app_url: Optional attribution URL, sent as ``HTTP-Referer``.
             app_name: Optional attribution name, sent as ``X-Title``.
@@ -242,7 +245,9 @@ class OpenRouterProvider(OpenAIProvider):
 
         base_url = kwargs.pop("base_url", OPENROUTER_BASE_URL)
         super().__init__(
-            model=model,
+            # None is allowed for discovery-only providers; inference is guarded
+            # by _require_model, so a None model never reaches the request.
+            model=model,  # type: ignore[arg-type]
             api_key=api_key,
             base_url=base_url,
             default_headers=headers or None,
@@ -283,6 +288,22 @@ class OpenRouterProvider(OpenAIProvider):
             catalog = await _fetch_catalog(self._models_url)
             _catalog_cache[self._models_url] = catalog
         return list(catalog.values())
+
+    def _require_model(self, kwargs: dict[str, Any]) -> str:
+        """Resolve the effective model for inference, raising if none is set.
+
+        A discovery-only provider (constructed without a model) can call
+        ``list_models()`` but not run — inference needs a concrete slug,
+        supplied at construction or per call.
+        """
+        model = kwargs.get("model") or self._model
+        if not model:
+            raise ValueError(
+                "OpenRouterProvider was created without a model. Pass "
+                "model='<slug>' to the constructor, or model=... per call, to "
+                "run inference — list_models() works without a model."
+            )
+        return model
 
     def _warn_once(self, model: str, reason: str, message: str) -> None:
         key = (model, reason)
@@ -343,8 +364,9 @@ class OpenRouterProvider(OpenAIProvider):
         **kwargs: Any,
     ) -> LLMResponse:
         """Send messages via OpenRouter; guards native tool support when tools are passed."""
+        model = self._require_model(kwargs)
         if tools:
-            await self._ensure_native_tool_support(kwargs.get("model", self._model))
+            await self._ensure_native_tool_support(model)
         return await super().complete(
             messages,
             tools,
@@ -365,8 +387,9 @@ class OpenRouterProvider(OpenAIProvider):
         **kwargs: Any,
     ) -> AsyncGenerator[StreamEvent, None]:
         """Stream via OpenRouter; guards native tool support when tools are passed."""
+        model = self._require_model(kwargs)
         if tools:
-            await self._ensure_native_tool_support(kwargs.get("model", self._model))
+            await self._ensure_native_tool_support(model)
         async for event in super().complete_stream(
             messages,
             tools,

--- a/packages/python/tests/unit/test_openrouter_provider.py
+++ b/packages/python/tests/unit/test_openrouter_provider.py
@@ -296,6 +296,58 @@ class TestGuardWiring:
 
 
 # ---------------------------------------------------------------------------
+# Optional model — discovery-only construction
+# ---------------------------------------------------------------------------
+class TestOptionalModel:
+    def test_construct_without_model(self) -> None:
+        provider = OpenRouterProvider(api_key="sk-or-test")
+        assert provider._model is None
+
+    def test_repr_without_model(self) -> None:
+        assert repr(OpenRouterProvider(api_key="sk-or-test")) == "OpenRouterProvider(model=None)"
+
+    async def test_list_models_works_without_model(self, catalog_ok: AsyncMock) -> None:
+        """The whole point: discovery needs no model."""
+        provider = OpenRouterProvider(api_key="sk-or-test")
+        models = await provider.list_models()
+        assert {m.id for m in models} == set(CATALOG)
+
+    async def test_complete_without_model_raises_before_request(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        provider = OpenRouterProvider(api_key="sk-or-test")
+        create = AsyncMock()
+        monkeypatch.setattr(provider._client.chat.completions, "create", create)
+        with pytest.raises(ValueError, match="without a model"):
+            await provider.complete([Message(role=Role.USER, content="hi")])
+        create.assert_not_awaited()
+
+    async def test_complete_stream_without_model_raises_before_request(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        provider = OpenRouterProvider(api_key="sk-or-test")
+        create = AsyncMock()
+        monkeypatch.setattr(provider._client.chat.completions, "create", create)
+        with pytest.raises(ValueError, match="without a model"):
+            stream = provider.complete_stream([Message(role=Role.USER, content="hi")])
+            async for _ in stream:
+                pass
+        create.assert_not_awaited()
+
+    async def test_per_call_model_enables_inference_without_constructor_model(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A model= override lets a discovery-only provider run a one-off call."""
+        sentinel = object()
+        monkeypatch.setattr(OpenAIProvider, "complete", AsyncMock(return_value=sentinel))
+        provider = OpenRouterProvider(api_key="sk-or-test")
+        result = await provider.complete(
+            [Message(role=Role.USER, content="hi")], model="deepseek/deepseek-chat"
+        )
+        assert result is sentinel
+
+
+# ---------------------------------------------------------------------------
 # extra_body flows into the request kwargs (OpenAIProvider passthrough)
 # ---------------------------------------------------------------------------
 class TestExtraBodyPassthrough:


### PR DESCRIPTION
## Why

Calling `list_models()` required constructing `OpenRouterProvider(model="…")` with a throwaway slug you never use — the listing path only reads `base_url`, never the model. This makes `model` optional so discovery needs no model.

## What

- **`model` is now optional** (`str | None = None`). `OpenRouterProvider()` builds a discovery-only provider.
- **Inference stays safe:** `complete` / `complete_stream` resolve the model via a new `_require_model` helper and raise a clear error if none was set (constructor *or* per-call) — no confusing `model=None` ever reaches the API.
- `list_models()` works with no model; a per-call `model=` still lets a discovery-only provider run a one-off call.
- Recipe: the `list_models()` example drops the now-unneeded `model=` arg.

The `None` is passed through to the parent `OpenAIProvider` (which stores it without validation); a single scoped `# type: ignore[arg-type]` documents that the inference guard covers it.

## Tests

New `TestOptionalModel`: construct-without-model, discovery works sans model, `complete`/`complete_stream` raise before any request when no model is set, and a per-call `model=` enables inference. Full suite: 1356 unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)