### PR TITLE
release: dendrux 0.2.0a11

### DIFF
--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dendrux"
-version = "0.2.0a10"
+version = "0.2.0a11"
 description = "The runtime for agents that act in the real world."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Release **0.2.0a11**.

## Included
- **feat(llm):** `OpenRouterProvider` model is now optional — construct a discovery-only provider for `list_models()` without a throwaway slug; inference raises a clear error if no model is set (#39)
- **docs:** OpenRouter recipe — "Persisting the catalog" pattern (snapshot → store → scheduled refresh → query by capability) + discovery-only `list_models()` example (#37)
- **fix(ci):** pin ruff to `0.15.17` for deterministic format checks (#38)

Version bumped in `pyproject.toml` (single source of truth; `__version__` reads it via `importlib.metadata`). Publish to PyPI is manual post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)