### PR TITLE
fix(build): make sdist deterministic with explicit include allowlist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,10 @@ htmlcov/
 scratch/
 **/scratch/
 
+# Generated example run output
+examples/**/output/
+**/examples/**/output/
+
 # Dashboard (React build artifacts — keep dir via .gitkeep, ignore contents)
 node_modules/
 packages/python/src/dendrite/dashboard/static/*

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -82,6 +82,23 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src/dendrux"]
 
+# Explicit allowlist so the sdist is deterministic: only these paths ship,
+# regardless of untracked working-tree files. Without it, hatchling's default
+# sweeps in anything not gitignored (e.g. session logs, generated example
+# output). The `output` exclude guards example runs that write in-tree.
+[tool.hatch.build.targets.sdist]
+include = [
+    "src",
+    "examples",
+    "README.md",
+    "LICENSE",
+    "alembic.ini",
+    "Makefile",
+]
+exclude = [
+    "**/output",
+]
+
 # --- Tool configs ---
 
 [tool.ruff]


### PR DESCRIPTION
## Problem

The sdist had no `[tool.hatch.build.targets.sdist]` config, so hatchling's default swept in **every** non-gitignored file under `packages/python/` — including untracked working-tree cruft. Caught during the `0.2.0a11` build: a session transcript `.txt` and generated `examples/**/output/*.md` leaked into the source tarball (removed by hand before that upload). The wheel was never affected (`packages = ["src/dendrux"]`).

## Fix

- **Explicit sdist allowlist** — only `src`, `examples`, `README.md`, `LICENSE`, `alembic.ini`, `Makefile` ship. Root-level cruft can no longer appear because it's not on the list.
- **`exclude = ["**/output"]`** guards example scripts that write output in-tree.
- **`.gitignore`**: `examples/**/output/` so generated runs are never tracked either.

Version is untouched — this rides the next release.

## Verification

Planted decoys in both leak vectors (a root-level `.txt` and an `examples/**/output/` dir), rebuilt, and confirmed:
- ✅ both decoys **excluded** from the sdist
- ✅ retained: 163 `src/dendrux` files, all 43 example `.py` files, README/LICENSE/alembic.ini/Makefile
- ✅ `twine check` passes; sdist still builds a working wheel

🤖 Generated with [Claude Code](https://claude.com/claude-code)