### PR TITLE
feat(openrouter): populate cost_usd + cache-creation tokens on UsageStats

### DIFF
--- a/docs/recipes/openrouter.mdx
+++ b/docs/recipes/openrouter.mdx
@@ -117,6 +117,27 @@ agent = Agent(provider=f"openrouter:{model['id']}", prompt="…")
 
 Everything past the fetch is yours: the schema, the refresh cadence, evicting slugs that vanished, and — the load-bearing part — what "best" means. dendrux surfaces the capability axes (tools, context, price, modalities); ranking across them is a product decision it never makes for you.
 
+## Usage and cost accounting
+
+OpenRouter returns real spend on every response — automatically, no request flag needed (the old `usage: {include: true}` opt-in is deprecated and always-on). dendrux maps it onto the same cross-provider `UsageStats` every provider reports, so cost is a first-class field, not something you reconstruct from a pricing table:
+
+- `usage.cost` → `cost_usd` — what OpenRouter charged your account for the call, in USD (the same unit as the per-token prices `list_models()` reports).
+- `prompt_tokens_details.cache_write_tokens` → `cache_creation_input_tokens`, alongside the `cached_tokens` → `cache_read_input_tokens` mapping every OpenAI-wire provider already gets.
+
+Both stream and non-stream paths are covered — cost rides the final SSE chunk — and per-call values roll up into run-level totals through the normal accumulator, so `RunStore` and the dashboard show cost per run with nothing extra to wire:
+
+```python
+resp = await agent.run("Summarize this thread.")
+print(resp.usage.cost_usd)                    # e.g. 0.000123  (USD)
+print(resp.usage.cache_creation_input_tokens) # tokens written to cache
+
+# Run-level total, aggregated across every iteration:
+run = await store.get_run(resp.run_id)
+print(run.total_cost_usd)
+```
+
+A model that reports no cost (a rare compatible backend) leaves `cost_usd` as `None`; a free model reporting `0.0` keeps the `0.0` — "didn't report" stays distinct from "reported zero." OpenRouter's `cost_details.upstream_inference_cost` (the underlying provider's cost, distinct from what OpenRouter billed you) isn't mapped to a first-class field in v1 — it's available on the raw response for anyone who needs the margin.
+
 ## Attribution and routing extras
 
 ```python

--- a/packages/python/src/dendrux/llm/openai.py
+++ b/packages/python/src/dendrux/llm/openai.py
@@ -485,7 +485,7 @@ class OpenAIProvider(LLMProvider):
         async for chunk in stream:
             # Usage arrives in the final chunk
             if chunk.usage:
-                usage = _build_usage_with_cache(chunk.usage)
+                usage = self._normalize_usage(chunk.usage)
 
             if not chunk.choices:
                 continue
@@ -675,6 +675,17 @@ class OpenAIProvider(LLMProvider):
     # Inbound conversions: OpenAI → Dendrux
     # ------------------------------------------------------------------
 
+    def _normalize_usage(self, usage: Any) -> UsageStats:
+        """Map a provider usage object to :class:`UsageStats`.
+
+        Overridable seam for OpenAI-compatible presets that return extra
+        usage fields on the same wire format (e.g. OpenRouter's ``cost`` and
+        ``cache_write_tokens``). The base implementation covers the standard
+        Chat Completions usage shape; both the streaming and non-streaming
+        paths route through here so an override enriches both at once.
+        """
+        return _build_usage_with_cache(usage)
+
     def _normalize_response(self, response: Any) -> LLMResponse:
         """Convert OpenAI ChatCompletion to Dendrux LLMResponse."""
         if not response.choices:
@@ -708,7 +719,7 @@ class OpenAIProvider(LLMProvider):
         # Extract usage
         usage = UsageStats()
         if response.usage:
-            usage = _build_usage_with_cache(response.usage)
+            usage = self._normalize_usage(response.usage)
 
         return LLMResponse(
             text=text,

--- a/packages/python/src/dendrux/llm/openrouter.py
+++ b/packages/python/src/dendrux/llm/openrouter.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 import logging
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any
 
 import httpx
@@ -37,7 +37,7 @@ from dendrux.llm.openai import OpenAIProvider
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
 
-    from dendrux.types import LLMResponse, Message, StreamEvent, ToolDef
+    from dendrux.types import LLMResponse, Message, StreamEvent, ToolDef, UsageStats
 
 logger = logging.getLogger(__name__)
 
@@ -170,6 +170,27 @@ async def _get_catalog(models_url: str) -> dict[str, OpenRouterModel] | None:
             )
             _catalog_cache[models_url] = None
     return _catalog_cache[models_url]
+
+
+def _read_usage_extra(obj: Any, field: str) -> Any:
+    """Read a non-standard usage field OpenRouter adds on the OpenAI wire.
+
+    The OpenAI SDK retains fields its schema does not define (``extra='allow'``),
+    so OpenRouter's ``cost`` / ``cache_write_tokens`` surface via attribute
+    access or ``model_extra``; a raw dict is handled too. Returns ``None`` when
+    the field is absent.
+    """
+    if obj is None:
+        return None
+    if isinstance(obj, dict):
+        return obj.get(field)
+    value = getattr(obj, field, None)
+    if value is not None:
+        return value
+    extra = getattr(obj, "model_extra", None)
+    if isinstance(extra, dict):
+        return extra.get(field)
+    return None
 
 
 class OpenRouterProvider(OpenAIProvider):
@@ -352,6 +373,35 @@ class OpenRouterProvider(OpenAIProvider):
         if self._require_native_tools:
             raise ValueError(message)
         self._warn_once(model, "no-native-tools", message)
+
+    def _normalize_usage(self, usage: Any) -> UsageStats:
+        """Enrich base usage with OpenRouter's cost and cache-write fields.
+
+        OpenRouter returns these on the standard usage object and they ride
+        through the OpenAI SDK as extra fields:
+
+          - ``cost`` → ``cost_usd``. USD-denominated, matching the USD
+            per-token pricing :meth:`list_models` already exposes; it is what
+            OpenRouter charged the account for this call. (``upstream_inference_cost``
+            stays available on the raw response — not mapped in v1.)
+          - ``prompt_tokens_details.cache_write_tokens`` →
+            ``cache_creation_input_tokens``, aligning with Anthropic's field.
+
+        A missing field leaves the base value unchanged; a reported zero (e.g.
+        free models) is preserved. Populating these at the source is enough —
+        the run-level accumulator and RunStore already carry both.
+        """
+        base = super()._normalize_usage(usage)
+        cost = _read_usage_extra(usage, "cost")
+        details = _read_usage_extra(usage, "prompt_tokens_details")
+        cache_write = _read_usage_extra(details, "cache_write_tokens")
+        return replace(
+            base,
+            cost_usd=float(cost) if cost is not None else base.cost_usd,
+            cache_creation_input_tokens=(
+                int(cache_write) if cache_write is not None else base.cache_creation_input_tokens
+            ),
+        )
 
     async def complete(
         self,

--- a/packages/python/tests/unit/test_openrouter_provider.py
+++ b/packages/python/tests/unit/test_openrouter_provider.py
@@ -11,6 +11,7 @@ All unit tests are fully mocked — no network.
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass, field
 from typing import Any
 from unittest.mock import AsyncMock
 
@@ -30,7 +31,7 @@ from dendrux.llm.openrouter import (  # noqa: E402
     OpenRouterProvider,
     _parse_model_entry,
 )
-from dendrux.types import Message, Role, ToolDef  # noqa: E402
+from dendrux.types import Message, Role, StreamEventType, ToolDef, UsageStats  # noqa: E402
 
 
 def _model(
@@ -545,3 +546,167 @@ class TestParseModelEntry:
         assert model.prompt_price is None
         assert model.completion_price is None
         assert not model.is_free
+
+
+# ---------------------------------------------------------------------------
+# Usage accounting — OpenRouter cost + cache-write mapping
+# ---------------------------------------------------------------------------
+def _usage(**fields: Any) -> Any:
+    """A real OpenAI CompletionUsage carrying OpenRouter's extra fields.
+
+    Built from the actual SDK type (``extra='allow'``) so the test exercises
+    the same extra-field retention production relies on — not a stand-in that
+    would pass regardless of whether the SDK keeps unknown fields.
+    """
+    from openai.types import CompletionUsage
+
+    base: dict[str, Any] = {"prompt_tokens": 100, "completion_tokens": 20, "total_tokens": 120}
+    base.update(fields)
+    return CompletionUsage.model_validate(base)
+
+
+@dataclass
+class _FakeDelta:
+    content: str | None = None
+    tool_calls: Any = None
+
+
+@dataclass
+class _FakeStreamChoice:
+    delta: _FakeDelta = field(default_factory=_FakeDelta)
+    index: int = 0
+    finish_reason: str | None = None
+
+
+@dataclass
+class _FakeChunk:
+    choices: list[Any] = field(default_factory=list)
+    usage: Any = None
+
+
+@dataclass
+class _FakeMessage:
+    role: str = "assistant"
+    content: str | None = "ok"
+    tool_calls: Any = None
+
+
+@dataclass
+class _FakeChoice:
+    message: _FakeMessage = field(default_factory=_FakeMessage)
+    index: int = 0
+    finish_reason: str = "stop"
+
+
+@dataclass
+class _FakeCompletion:
+    choices: list[Any] = field(default_factory=lambda: [_FakeChoice()])
+    usage: Any = None
+
+    def model_dump(self) -> dict[str, Any]:
+        return {"fake": True}
+
+
+async def _astream(chunks: list[Any]) -> Any:
+    for chunk in chunks:
+        yield chunk
+
+
+class TestUsageAccounting:
+    """OpenRouter maps its extra usage fields onto the cross-provider UsageStats.
+
+    ``cost`` -> ``cost_usd`` (USD; what OpenRouter charged the account) and
+    ``prompt_tokens_details.cache_write_tokens`` -> ``cache_creation_input_tokens``.
+    Populating these at the source is enough — the run-level accumulator and
+    RunStore already carry both.
+    """
+
+    def test_cost_mapped_to_cost_usd(self) -> None:
+        stats = _provider()._normalize_usage(_usage(cost=0.000123))
+        assert stats.cost_usd == pytest.approx(0.000123)
+
+    def test_cache_write_mapped_to_cache_creation(self) -> None:
+        stats = _provider()._normalize_usage(
+            _usage(prompt_tokens_details={"cached_tokens": 40, "cache_write_tokens": 10})
+        )
+        assert stats.cache_creation_input_tokens == 10
+        # base mapping still holds: cached-read + fresh-input normalization
+        assert stats.cache_read_input_tokens == 40
+        assert stats.input_tokens == 60
+
+    def test_missing_cost_leaves_none(self) -> None:
+        """A compatible backend that omits cost must not fabricate a number."""
+        stats = _provider()._normalize_usage(_usage())
+        assert stats.cost_usd is None
+        assert stats.cache_creation_input_tokens is None
+
+    def test_zero_cost_preserved(self) -> None:
+        """Free models report cost 0.0 — a reported zero survives, not -> None."""
+        stats = _provider()._normalize_usage(_usage(cost=0.0))
+        assert stats.cost_usd == 0.0
+
+    def test_base_reasoning_tokens_preserved_through_override(self) -> None:
+        stats = _provider()._normalize_usage(
+            _usage(completion_tokens_details={"reasoning_tokens": 5})
+        )
+        assert stats.reasoning_tokens == 5
+
+    async def test_non_streaming_complete_surfaces_cost(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        provider = _provider()
+        completion = _FakeCompletion(
+            usage=_usage(cost=0.0005, prompt_tokens_details={"cache_write_tokens": 8})
+        )
+        monkeypatch.setattr(
+            provider._client.chat.completions, "create", AsyncMock(return_value=completion)
+        )
+        result = await provider.complete([Message(role=Role.USER, content="hi")])
+        assert result.usage.cost_usd == pytest.approx(0.0005)
+        assert result.usage.cache_creation_input_tokens == 8
+
+    async def test_streaming_final_chunk_surfaces_cost(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        provider = _provider()
+        chunks = [
+            _FakeChunk(choices=[_FakeStreamChoice(delta=_FakeDelta(content="hi"))]),
+            # OpenRouter attaches usage to the final SSE chunk (empty choices)
+            _FakeChunk(
+                choices=[],
+                usage=_usage(cost=0.0009, prompt_tokens_details={"cache_write_tokens": 3}),
+            ),
+        ]
+        monkeypatch.setattr(
+            provider._client.chat.completions,
+            "create",
+            AsyncMock(return_value=_astream(chunks)),
+        )
+        done = None
+        async for event in provider.complete_stream([Message(role=Role.USER, content="hi")]):
+            if event.type == StreamEventType.DONE:
+                done = event
+        assert done is not None
+        assert done.raw.usage.cost_usd == pytest.approx(0.0009)
+        assert done.raw.usage.cache_creation_input_tokens == 3
+
+    def test_multi_iteration_aggregation(self) -> None:
+        """Per-call cost + cache-write sum into the run-level total."""
+        from dendrux.loops.react import _accumulate_usage
+
+        provider = _provider()
+        total = UsageStats()
+        _accumulate_usage(
+            total,
+            provider._normalize_usage(
+                _usage(cost=0.001, prompt_tokens_details={"cache_write_tokens": 10})
+            ),
+        )
+        _accumulate_usage(
+            total,
+            provider._normalize_usage(
+                _usage(cost=0.002, prompt_tokens_details={"cache_write_tokens": 5})
+            ),
+        )
+        assert total.cost_usd == pytest.approx(0.003)
+        assert total.cache_creation_input_tokens == 15


### PR DESCRIPTION
## What & why

The Oreo team hit an observability gap: `OpenRouterProvider` inherited the OpenAI Chat Completions usage normalization, which maps prompt/completion/cached-read/reasoning tokens but **not cost or cache-write tokens**. So `UsageStats.cost_usd` and `cache_creation_input_tokens` stayed empty for OpenRouter runs even though OpenRouter returns that data on every response.

OpenRouter now includes full usage accounting automatically (the old `usage: {include: true}` opt-in is deprecated/always-on), and the OpenAI SDK retains its extra fields (`extra="allow"`), so no OpenRouter SDK is needed — we just read them off the same `usage` object.

## Change

- **`OpenAIProvider._normalize_usage`** — new overridable hook; both `complete()` and `complete_stream()` route through it (was a module-level function used at both call sites).
- **`OpenRouterProvider._normalize_usage`** override:
  - `usage.cost` → `cost_usd` (USD — same unit as the per-token prices `list_models()` reports; what OpenRouter billed the account)
  - `prompt_tokens_details.cache_write_tokens` → `cache_creation_input_tokens` (aligns with Anthropic's field)
  - Missing cost → `None`; a reported `0.0` (free models) is preserved.
  - `cost_details.upstream_inference_cost` left on the raw response, **not** mapped to a first-class field in v1.

## Notably

- **No migration.** Both DB columns already exist; the run-level accumulator and `RunStore` already carry `cost_usd`/`cache_creation_input_tokens`. This only populates the source — OpenRouter is the first provider to actually light up `cost_usd`.
- Streaming and non-streaming both covered (cost rides the final SSE chunk).

## Tests

`TestUsageAccounting`: direct mapping (using the real `CompletionUsage` type to exercise extra-field retention), missing-cost→None, zero-cost preserved, cache-write mapping, reasoning passthrough, non-streaming `complete()`, streaming final-chunk, and multi-iteration run-level aggregation. Full suite: 1639 passed. `make ci` green (ruff, ruff-format, mypy).

Authored-By: Anmol Gautam <anmolgautam2428@gmail.com>
Assisted-By: Claude <noreply@anthropic.com>