### PR TITLE
release: dendrux 0.2.0a12

### DIFF
--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dendrux"
-version = "0.2.0a11"
+version = "0.2.0a12"
 description = "The runtime for agents that act in the real world."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Release **0.2.0a12**.

## Included
- **#42** — OpenRouter usage accounting: `usage.cost` → `cost_usd` (USD) and `prompt_tokens_details.cache_write_tokens` → `cache_creation_input_tokens`, on both streaming and non-streaming paths. First provider to populate `cost_usd`; per-call values aggregate into run-level totals. No migration.
- **#41** — deterministic sdist via explicit `[tool.hatch.build.targets.sdist]` allowlist (first release to carry it).

## Version
`pyproject.toml`: `0.2.0a11` → `0.2.0a12` (single source of truth; `__version__` reads it via `importlib.metadata`).

## Post-merge
Manual `twine upload` by the maintainer (no CI publish). Dist will be built + `twine check`ed against this tag.

Authored-By: Anmol Gautam <anmolgautam2428@gmail.com>
Assisted-By: Claude <noreply@anthropic.com>