### PR TITLE
feat(openrouter): reasoning controls, capability metadata, content capture

### DIFF
--- a/docs/recipes/openrouter.mdx
+++ b/docs/recipes/openrouter.mdx
@@ -169,9 +169,13 @@ for m in await provider.list_models():
     caps = m.reasoning
     caps.supported          # accepts a reasoning parameter at all
     caps.mandatory          # reasoning can't be disabled → hide "Off"
-    caps.supported_efforts  # ("high","medium","low",…); () ⇒ budget-based, not effort-based
-    caps.default_effort     # the model's default when on
+    caps.supported_efforts   # ("high","medium","low",…); () ⇒ no effort selector
+    caps.default_effort      # the model's default effort when on
+    caps.default_enabled     # whether reasoning is on by default (bool | None)
+    caps.supports_max_tokens # takes a reasoning.max_tokens budget → show a budget control
 ```
+
+For a token budget instead of an effort level (Anthropic/Gemini/some Qwen), pass it straight through: `extra_body={"reasoning": {"max_tokens": 2000}}`.
 
 ### Reasoning tokens vs. reasoning text
 

--- a/docs/recipes/openrouter.mdx
+++ b/docs/recipes/openrouter.mdx
@@ -138,6 +138,53 @@ print(run.total_cost_usd)
 
 A model that reports no cost (a rare compatible backend) leaves `cost_usd` as `None`; a free model reporting `0.0` keeps the `0.0` — "didn't report" stays distinct from "reported zero." OpenRouter's `cost_details.upstream_inference_cost` (the underlying provider's cost, distinct from what OpenRouter billed you) isn't mapped to a first-class field in v1 — it's available on the raw response for anyone who needs the margin.
 
+## Reasoning controls
+
+Reasoning-capable models (DeepSeek R1, Qwen3, GPT-5, …) reason **by default** on OpenRouter — so an app that omits reasoning config and shows "Think: Off" is misleading: the model still burns reasoning tokens. dendrux wires reasoning into its cross-vendor knobs so you send the right directive with one flag.
+
+```python
+from dendrux.llm.openrouter import OpenRouterProvider
+
+# Off — sends reasoning={"enabled": False}
+OpenRouterProvider(model="qwen/qwen3-14b", thinking=False)
+
+# On at a chosen depth — sends reasoning={"effort": "medium"}
+OpenRouterProvider(model="qwen/qwen3-14b", thinking=True, effort="medium")
+```
+
+- `thinking=False` → `reasoning={"enabled": False}` — OpenRouter's disable directive. (Verified against live models: `effort="none"` does *not* disable reasoning on Qwen3, and `exclude` still bills reasoning tokens — `enabled: false` is the right one.) On a model whose metadata marks reasoning **mandatory**, this raises before the request.
+
+> **Reliability caveat.** A true zero depends on the model's OpenRouter **upstream** honoring the disable. Some Qwen3 hosts ignore the reasoning toggle and keep reasoning regardless — dendrux sends the correct directive, but can't force an upstream to obey it. When a hard zero matters, pin a compliant upstream: `extra_body={"provider": {"order": ["<host>"], "allow_fallbacks": False}}`, and confirm with `call.reasoning_tokens` (below).
+>
+> Recording stays honest either way: if a model reasons **despite** `thinking=False`, those reasoning tokens — and any reasoning text it emits — are recorded as-is. dendrux reports what the model actually did (and billed), never what you asked for, so cost and observability stay accurate even when a directive is ignored.
+- `effort` is the cross-vendor knob (`low`/`medium`/`high`/`xhigh`; `"extra"`→`xhigh`); OpenRouter also accepts `minimal`/`none`. It works even on budget-based models — OpenRouter cross-converts effort↔max_tokens.
+- Both are overridable per call.
+
+### Rendering Off / Low / Medium / High / Always-on
+
+`list_models()` carries the metadata to build the control — and to hide "Off" when it isn't allowed:
+
+```python
+for m in await provider.list_models():
+    caps = m.reasoning
+    caps.supported          # accepts a reasoning parameter at all
+    caps.mandatory          # reasoning can't be disabled → hide "Off"
+    caps.supported_efforts  # ("high","medium","low",…); () ⇒ budget-based, not effort-based
+    caps.default_effort     # the model's default when on
+```
+
+### Reasoning tokens vs. reasoning text
+
+These are **separate** response data: `reasoning_tokens` counts internal reasoning the model billed; `reasoning` is a human-readable summary the provider *chose* to expose (often absent). dendrux surfaces both on the public LLM call, so an app can say precisely "reasoning happened, but no readable summary was recorded":
+
+```python
+call = (await store.get_llm_calls(run_id))[-1]
+call.reasoning_tokens   # e.g. 773  — reasoning happened
+call.reasoning          # None      — but no reasoning text was exposed
+```
+
+Across multi-step tool calls, dendrux preserves OpenRouter's `reasoning_details` and replays them on later turns (per OpenRouter's guidance), so the model keeps its reasoning context through a tool loop — and streamed reasoning arrives as `reasoning_delta` run events.
+
 ## Attribution and routing extras
 
 ```python

--- a/packages/python/src/dendrux/llm/openai.py
+++ b/packages/python/src/dendrux/llm/openai.py
@@ -694,11 +694,16 @@ class OpenAIProvider(LLMProvider):
                     ]
                 else:
                     api_msg = {"role": "assistant", "content": msg.content}
-                # Replay provider reasoning artifacts verbatim so multi-step
-                # tool calls keep the model's reasoning context, per OpenRouter's
-                # guidance. Inert for pure OpenAI, which never populates these.
+                # Replay provider reasoning so multi-step tool calls keep the
+                # model's reasoning context, per OpenRouter's guidance. Prefer
+                # the structured blocks (verbatim — required for encrypted/
+                # summarized types); fall back to the plaintext string for
+                # models that only return raw reasoning. Inert for pure OpenAI,
+                # which never populates either.
                 if msg.reasoning_blocks:
                     api_msg["reasoning_details"] = msg.reasoning_blocks
+                elif msg.reasoning:
+                    api_msg["reasoning"] = msg.reasoning
                 api_messages.append(api_msg)
 
             elif msg.role == Role.TOOL:

--- a/packages/python/src/dendrux/llm/openai.py
+++ b/packages/python/src/dendrux/llm/openai.py
@@ -73,6 +73,44 @@ def _reasoning_tokens_from(details: Any) -> int | None:
     return None
 
 
+def _extra_attr(obj: Any, field: str) -> Any:
+    """Read a field that may live in a Pydantic model's ``model_extra``.
+
+    OpenAI-compatible backends (notably OpenRouter) return reasoning fields
+    the OpenAI schema doesn't define; ``extra='allow'`` keeps them, reachable
+    via attribute access or ``model_extra``. Pure OpenAI returns none of them,
+    so every reader below is inert there.
+    """
+    value = getattr(obj, field, None)
+    if value is not None:
+        return value
+    extra = getattr(obj, "model_extra", None)
+    if isinstance(extra, dict):
+        return extra.get(field)
+    return None
+
+
+def _reasoning_text_from(obj: Any) -> str | None:
+    """Reasoning summary text from a message or stream delta.
+
+    OpenRouter surfaces it as ``reasoning`` (``reasoning_content`` is an
+    accepted alias). Empty strings collapse to ``None`` so "no text exposed"
+    stays distinct from "reasoning happened" (which ``reasoning_tokens`` marks).
+    """
+    for field in ("reasoning", "reasoning_content"):
+        value = _extra_attr(obj, field)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _reasoning_details_from(obj: Any) -> list[Any] | None:
+    """Opaque reasoning artifacts (``reasoning_details``) to replay verbatim
+    across tool-call iterations, per OpenRouter's guidance."""
+    value = _extra_attr(obj, "reasoning_details")
+    return value if isinstance(value, list) and value else None
+
+
 def _build_usage_with_cache(usage: Any) -> UsageStats:
     """Build UsageStats from an OpenAI Chat Completions usage object.
 
@@ -474,6 +512,8 @@ class OpenAIProvider(LLMProvider):
         # Accumulators for building the final LLMResponse
         text_parts: list[str] = []
         tool_calls: list[ToolCall] = []
+        reasoning_parts: list[str] = []
+        reasoning_block_acc: list[Any] = []
         usage = UsageStats()
         finish_reason: str | None = None
 
@@ -492,6 +532,16 @@ class OpenAIProvider(LLMProvider):
 
             choice = chunk.choices[0]
             delta = choice.delta
+
+            # --- Reasoning deltas (OpenRouter/compatible; inert on pure OpenAI) ---
+            # Reasoning streams before content, so emit it first.
+            reasoning_delta = _reasoning_text_from(delta)
+            if reasoning_delta:
+                reasoning_parts.append(reasoning_delta)
+                yield StreamEvent(type=StreamEventType.REASONING_DELTA, text=reasoning_delta)
+            reasoning_detail_delta = _reasoning_details_from(delta)
+            if reasoning_detail_delta:
+                reasoning_block_acc.extend(reasoning_detail_delta)
 
             # --- Text deltas ---
             if delta.content:
@@ -585,6 +635,8 @@ class OpenAIProvider(LLMProvider):
             tool_calls=tool_calls if tool_calls else None,
             raw=None,
             usage=usage,
+            reasoning="".join(reasoning_parts) if reasoning_parts else None,
+            reasoning_blocks=reasoning_block_acc if reasoning_block_acc else None,
         )
         llm_response.provider_request = captured_request
         llm_response.model = captured_request["model"]
@@ -640,9 +692,14 @@ class OpenAIProvider(LLMProvider):
                         }
                         for tc in msg.tool_calls
                     ]
-                    api_messages.append(api_msg)
                 else:
-                    api_messages.append({"role": "assistant", "content": msg.content})
+                    api_msg = {"role": "assistant", "content": msg.content}
+                # Replay provider reasoning artifacts verbatim so multi-step
+                # tool calls keep the model's reasoning context, per OpenRouter's
+                # guidance. Inert for pure OpenAI, which never populates these.
+                if msg.reasoning_blocks:
+                    api_msg["reasoning_details"] = msg.reasoning_blocks
+                api_messages.append(api_msg)
 
             elif msg.role == Role.TOOL:
                 original_call = resolve_tool_message_call(msg, call_index)
@@ -726,4 +783,6 @@ class OpenAIProvider(LLMProvider):
             tool_calls=tool_calls,
             raw=response,
             usage=usage,
+            reasoning=_reasoning_text_from(message),
+            reasoning_blocks=_reasoning_details_from(message),
         )

--- a/packages/python/src/dendrux/llm/openrouter.py
+++ b/packages/python/src/dendrux/llm/openrouter.py
@@ -61,10 +61,20 @@ class OpenRouterReasoningCapabilities:
     empty when the model is budget-based (``max_tokens``) rather than effort-based."""
     default_effort: str | None
     """The model's default effort when reasoning is on, when advertised."""
+    default_enabled: bool | None
+    """Whether reasoning is on by default, when advertised (else ``None``)."""
+    supports_max_tokens: bool
+    """True when the model takes a ``reasoning.max_tokens`` budget (show a token
+    budget control) rather than only effort levels."""
 
 
 _NO_REASONING = OpenRouterReasoningCapabilities(
-    supported=False, mandatory=False, supported_efforts=(), default_effort=None
+    supported=False,
+    mandatory=False,
+    supported_efforts=(),
+    default_effort=None,
+    default_enabled=None,
+    supports_max_tokens=False,
 )
 
 
@@ -158,10 +168,16 @@ def _parse_reasoning(
     raw = entry.get("reasoning")
     if not isinstance(raw, dict):
         return OpenRouterReasoningCapabilities(
-            supported=supported, mandatory=False, supported_efforts=(), default_effort=None
+            supported=supported,
+            mandatory=False,
+            supported_efforts=(),
+            default_effort=None,
+            default_enabled=None,
+            supports_max_tokens=False,
         )
     efforts = raw.get("supported_efforts")
     default_effort = raw.get("default_effort")
+    default_enabled = raw.get("default_enabled")
     return OpenRouterReasoningCapabilities(
         supported=supported,
         mandatory=bool(raw.get("mandatory", False)),
@@ -169,6 +185,8 @@ def _parse_reasoning(
             tuple(e for e in efforts if isinstance(e, str)) if isinstance(efforts, list) else ()
         ),
         default_effort=default_effort if isinstance(default_effort, str) else None,
+        default_enabled=default_enabled if isinstance(default_enabled, bool) else None,
+        supports_max_tokens=bool(raw.get("supports_max_tokens", False)),
     )
 
 

--- a/packages/python/src/dendrux/llm/openrouter.py
+++ b/packages/python/src/dendrux/llm/openrouter.py
@@ -32,7 +32,7 @@ from typing import TYPE_CHECKING, Any
 
 import httpx
 
-from dendrux.llm.openai import OpenAIProvider
+from dendrux.llm.openai import OpenAIProvider, _normalize_effort
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
@@ -42,6 +42,30 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+@dataclass(frozen=True, slots=True)
+class OpenRouterReasoningCapabilities:
+    """A model's reasoning capabilities, from OpenRouter's ``/models`` metadata.
+
+    Enough for an app to render Off / Low / Medium / High / Always-on controls
+    and to know when "Off" is not an option.
+    """
+
+    supported: bool
+    """True when the model accepts a ``reasoning`` request parameter."""
+    mandatory: bool
+    """True when reasoning cannot be disabled — an app should hide "Off"."""
+    supported_efforts: tuple[str, ...]
+    """Effort levels the model accepts (e.g. ``("high", "medium", "low")``);
+    empty when the model is budget-based (``max_tokens``) rather than effort-based."""
+    default_effort: str | None
+    """The model's default effort when reasoning is on, when advertised."""
+
+
+_NO_REASONING = OpenRouterReasoningCapabilities(
+    supported=False, mandatory=False, supported_efforts=(), default_effort=None
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -69,11 +93,18 @@ class OpenRouterModel:
     """Accepted input modalities (``"text"``, ``"image"``, ...); empty if unknown."""
     output_modalities: tuple[str, ...]
     """Produced output modalities; empty if unknown."""
+    reasoning: OpenRouterReasoningCapabilities = _NO_REASONING
+    """Reasoning capabilities (support, mandatory, efforts) from ``/models``."""
 
     @property
     def supports_tools(self) -> bool:
         """True when the model advertises native function calling."""
         return "tools" in self.supported_parameters
+
+    @property
+    def supports_reasoning(self) -> bool:
+        """True when the model accepts reasoning controls."""
+        return self.reasoning.supported
 
     @property
     def is_free(self) -> bool:
@@ -114,6 +145,33 @@ def _parse_modalities(arch: dict[str, Any], key: str, side: int) -> tuple[str, .
     return ()
 
 
+def _parse_reasoning(
+    entry: dict[str, Any], supported_parameters: tuple[str, ...]
+) -> OpenRouterReasoningCapabilities:
+    """Read reasoning capabilities from a ``/models`` entry.
+
+    ``supported`` is derived from ``supported_parameters`` (OpenRouter has no
+    standalone flag); ``mandatory``/``supported_efforts``/``default_effort``
+    come from the nested ``reasoning`` object when present.
+    """
+    supported = "reasoning" in supported_parameters
+    raw = entry.get("reasoning")
+    if not isinstance(raw, dict):
+        return OpenRouterReasoningCapabilities(
+            supported=supported, mandatory=False, supported_efforts=(), default_effort=None
+        )
+    efforts = raw.get("supported_efforts")
+    default_effort = raw.get("default_effort")
+    return OpenRouterReasoningCapabilities(
+        supported=supported,
+        mandatory=bool(raw.get("mandatory", False)),
+        supported_efforts=(
+            tuple(e for e in efforts if isinstance(e, str)) if isinstance(efforts, list) else ()
+        ),
+        default_effort=default_effort if isinstance(default_effort, str) else None,
+    )
+
+
 def _parse_model_entry(entry: dict[str, Any]) -> OpenRouterModel | None:
     model_id = entry.get("id")
     if not isinstance(model_id, str):
@@ -122,15 +180,17 @@ def _parse_model_entry(entry: dict[str, Any]) -> OpenRouterModel | None:
     pricing = entry.get("pricing") or {}
     arch = entry.get("architecture") or {}
     context_length = entry.get("context_length")
+    supported_parameters = tuple(p for p in params if isinstance(p, str))
     return OpenRouterModel(
         id=model_id,
         name=entry.get("name") or model_id,
         context_length=int(context_length) if isinstance(context_length, int | float) else None,
-        supported_parameters=tuple(p for p in params if isinstance(p, str)),
+        supported_parameters=supported_parameters,
         prompt_price=_parse_price(pricing.get("prompt")),
         completion_price=_parse_price(pricing.get("completion")),
         input_modalities=_parse_modalities(arch, "input_modalities", 0),
         output_modalities=_parse_modalities(arch, "output_modalities", 1),
+        reasoning=_parse_reasoning(entry, supported_parameters),
     )
 
 
@@ -218,6 +278,8 @@ class OpenRouterProvider(OpenAIProvider):
         app_url: str | None = None,
         app_name: str | None = None,
         require_native_tools: bool = True,
+        thinking: bool | None = None,
+        effort: str | None = None,
         extra_body: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> None:
@@ -236,6 +298,20 @@ class OpenRouterProvider(OpenAIProvider):
                 whose catalog metadata lacks native tool support raises instead
                 of silently returning text that ignores the tools. Set False to
                 downgrade to a warning.
+            thinking: Reasoning on/off. ``False`` sends ``reasoning={"enabled":
+                False}`` — OpenRouter's disable directive (not ``exclude``,
+                which still bills reasoning). Yields zero reasoning tokens on
+                upstreams that honor it; some Qwen3 hosts ignore the toggle, so
+                pin a compliant upstream via ``extra_body`` when a hard zero is
+                required. ``True`` enables reasoning (with ``effort`` if given,
+                else the model default). ``None`` (default) leaves the request
+                untouched. Overridable per call. On a model whose catalog
+                metadata marks reasoning ``mandatory``, ``thinking=False`` raises.
+            effort: Reasoning effort — the cross-vendor knob (``low``/``medium``/
+                ``high``/``xhigh``; ``"extra"``→``xhigh``). OpenRouter also
+                accepts ``minimal`` and ``none``. Sent as ``reasoning={"effort":
+                ...}``; OpenRouter cross-converts effort↔max_tokens, so it works
+                on budget-based models too. Overridable per call.
             extra_body: Extra JSON fields for the request body. Merged with the
                 default ``provider`` routing block; keys you set win, and your
                 ``provider`` entries merge over ``require_parameters=True``.
@@ -276,6 +352,12 @@ class OpenRouterProvider(OpenAIProvider):
             **kwargs,
         )
         self._require_native_tools = require_native_tools
+        # Reasoning defaults (overridable per call). Named to avoid colliding
+        # with OpenAIProvider's own `_effort`/`_reasoning_effort`, which drive
+        # the `reasoning_effort` top-level param — OpenRouter instead routes
+        # reasoning through its unified `reasoning` request block.
+        self._default_thinking = thinking
+        self._default_effort = effort
         self._models_url = base_url.rstrip("/") + "/models"
         self._tools_verified: set[str] = set()
         self._tool_warnings_emitted: set[tuple[str, str]] = set()
@@ -374,6 +456,84 @@ class OpenRouterProvider(OpenAIProvider):
             raise ValueError(message)
         self._warn_once(model, "no-native-tools", message)
 
+    @staticmethod
+    def _reasoning_block(thinking: bool | None, effort: str | None) -> dict[str, Any] | None:
+        """Build OpenRouter's ``reasoning`` request block, or None to omit it.
+
+        ``thinking=False`` wins and sends ``{"enabled": False}`` — OpenRouter's
+        standard disable directive, and the one to prefer (verified live:
+        ``effort="none"`` does *not* disable on Qwen3, and ``exclude`` still
+        bills reasoning, just hides it). Whether it yields zero reasoning
+        tokens depends on the model's upstream honoring it — some (e.g. certain
+        Qwen3 hosts) ignore the toggle; pin a compliant upstream via
+        ``extra_body={"provider": {...}}`` when a hard zero is required.
+        Otherwise an explicit ``effort`` is used, then a bare ``thinking=True``
+        enables the model default. When nothing is set, the request is
+        untouched.
+        """
+        if thinking is False:
+            return {"enabled": False}
+        if effort is not None:
+            return {"effort": _normalize_effort(effort)}
+        if thinking is True:
+            return {"enabled": True}
+        return None
+
+    def _resolve_reasoning(
+        self, kwargs: dict[str, Any]
+    ) -> tuple[bool | None, dict[str, Any] | None]:
+        """Pop per-call ``thinking``/``effort`` (over constructor defaults) and
+        build the reasoning block. Popping keeps them from reaching the base
+        provider, which would otherwise route them to ``reasoning_effort``."""
+        thinking = kwargs.pop("thinking", self._default_thinking)
+        effort = kwargs.pop("effort", self._default_effort)
+        return thinking, self._reasoning_block(thinking, effort)
+
+    async def _ensure_reasoning_allowed(self, model: str, thinking: bool | None) -> None:
+        """Refuse ``thinking=False`` on a model that mandates reasoning.
+
+        Keyed on catalog metadata like the native-tools guard; a metadata
+        hiccup degrades to a warning rather than a broken run.
+        """
+        if thinking is not False:
+            return
+        catalog = await _get_catalog(self._models_url)
+        if catalog is None:
+            self._warn_once(
+                model,
+                "reasoning-catalog-unavailable",
+                f"OpenRouter model catalog unavailable — cannot verify whether "
+                f"{model!r} allows disabling reasoning. Proceeding.",
+            )
+            return
+        entry = catalog.get(model)
+        if entry is None:
+            self._warn_once(
+                model,
+                "reasoning-unknown-model",
+                f"Model {model!r} not found in the OpenRouter catalog — cannot verify "
+                f"whether reasoning can be disabled. Proceeding.",
+            )
+            return
+        if entry.reasoning.mandatory:
+            raise ValueError(
+                f"Model {model!r} (via OpenRouter) has mandatory reasoning — it cannot "
+                f"be turned off, so thinking=False is invalid. Check "
+                f"OpenRouterModel.reasoning.mandatory to hide the Off option in your UI, "
+                f"or omit thinking to use the model's reasoning."
+            )
+
+    @staticmethod
+    def _apply_reasoning(kwargs: dict[str, Any], reasoning: dict[str, Any] | None) -> None:
+        """Merge the reasoning block into per-call ``extra_body`` (ours wins).
+
+        Sits alongside the constructor ``provider`` routing block, which the
+        base provider merges separately — different key, no clobber.
+        """
+        if reasoning is None:
+            return
+        kwargs["extra_body"] = {**(kwargs.get("extra_body") or {}), "reasoning": reasoning}
+
     def _normalize_usage(self, usage: Any) -> UsageStats:
         """Enrich base usage with OpenRouter's cost and cache-write fields.
 
@@ -415,8 +575,11 @@ class OpenRouterProvider(OpenAIProvider):
     ) -> LLMResponse:
         """Send messages via OpenRouter; guards native tool support when tools are passed."""
         model = self._require_model(kwargs)
+        thinking, reasoning = self._resolve_reasoning(kwargs)
         if tools:
             await self._ensure_native_tool_support(model)
+        await self._ensure_reasoning_allowed(model, thinking)
+        self._apply_reasoning(kwargs, reasoning)
         return await super().complete(
             messages,
             tools,
@@ -438,8 +601,11 @@ class OpenRouterProvider(OpenAIProvider):
     ) -> AsyncGenerator[StreamEvent, None]:
         """Stream via OpenRouter; guards native tool support when tools are passed."""
         model = self._require_model(kwargs)
+        thinking, reasoning = self._resolve_reasoning(kwargs)
         if tools:
             await self._ensure_native_tool_support(model)
+        await self._ensure_reasoning_allowed(model, thinking)
+        self._apply_reasoning(kwargs, reasoning)
         async for event in super().complete_stream(
             messages,
             tools,

--- a/packages/python/src/dendrux/loops/react.py
+++ b/packages/python/src/dendrux/loops/react.py
@@ -229,6 +229,8 @@ async def _append_assistant(
         role=Role.ASSISTANT,
         content=response.text or "",
         tool_calls=response.tool_calls,
+        reasoning=response.reasoning,
+        reasoning_blocks=response.reasoning_blocks,
     )
     history.append(msg)
     await _record_message(recorder, run_id, msg, iteration)

--- a/packages/python/src/dendrux/types.py
+++ b/packages/python/src/dendrux/types.py
@@ -91,6 +91,11 @@ class Message:
     kind: str = "chat"
     placement: str = "dynamic"
     source: str | None = None
+    # Reasoning the model surfaced on an ASSISTANT turn: ``reasoning`` is the
+    # human-readable summary (never raw CoT); ``reasoning_blocks`` are opaque
+    # provider artifacts replayed verbatim across tool-call iterations.
+    reasoning: str | None = None
+    reasoning_blocks: list[Any] | None = None
 
     def __post_init__(self) -> None:
         if self.placement not in ("stable", "dynamic"):
@@ -502,6 +507,12 @@ def _message_to_dict(m: Message) -> dict[str, Any]:
         d["placement"] = m.placement
     if m.source is not None:
         d["source"] = m.source
+    # Reasoning summary + opaque replay blocks — persisted so a run paused
+    # mid-tool-loop keeps its reasoning context across resume.
+    if m.reasoning is not None:
+        d["reasoning"] = m.reasoning
+    if m.reasoning_blocks is not None:
+        d["reasoning_blocks"] = m.reasoning_blocks
     return d
 
 
@@ -519,6 +530,8 @@ def _message_from_dict(d: dict[str, Any]) -> Message:
         kind=d.get("kind", "chat"),
         placement=d.get("placement", "dynamic"),
         source=d.get("source"),
+        reasoning=d.get("reasoning"),
+        reasoning_blocks=d.get("reasoning_blocks"),
     )
 
 

--- a/packages/python/tests/unit/test_openai_provider.py
+++ b/packages/python/tests/unit/test_openai_provider.py
@@ -1346,3 +1346,146 @@ class TestReasoning:
     def test_bc_no_reasoning_tokens_when_absent(self, provider: OpenAIProvider) -> None:
         resp = FakeChatCompletion(choices=[FakeChoice(message=FakeMessage(content="hi"))])
         assert provider._normalize_response(resp).usage.reasoning_tokens is None
+
+
+# ---------------------------------------------------------------------------
+# Reasoning content capture (OpenRouter/compatible extras on the OpenAI wire)
+# ---------------------------------------------------------------------------
+@dataclass
+class _RMsg:
+    content: str | None = "answer"
+    tool_calls: Any = None
+    reasoning: str | None = None
+    reasoning_details: Any = None
+
+
+@dataclass
+class _RChoice:
+    message: _RMsg = field(default_factory=_RMsg)
+    index: int = 0
+    finish_reason: str = "stop"
+
+
+@dataclass
+class _RCompletion:
+    choices: list[Any] = field(default_factory=lambda: [_RChoice()])
+    usage: Any = None
+
+    def model_dump(self) -> dict[str, Any]:
+        return {"fake": True}
+
+
+@dataclass
+class _RDelta:
+    content: str | None = None
+    tool_calls: Any = None
+    reasoning: str | None = None
+    reasoning_details: Any = None
+
+
+class TestReasoningCapture:
+    """message.reasoning / reasoning_details -> LLMResponse fields.
+
+    Inert for pure OpenAI (returns neither); exercised by OpenRouter, which
+    rides this same transport.
+    """
+
+    def test_non_streaming_captures_text_and_blocks(self, provider: OpenAIProvider) -> None:
+        blocks = [{"type": "reasoning.text", "text": "step 1", "id": "r1"}]
+        comp = _RCompletion(
+            choices=[
+                _RChoice(
+                    message=_RMsg(content="42", reasoning="thinking", reasoning_details=blocks)
+                )
+            ]
+        )
+        r = provider._normalize_response(comp)
+        assert r.reasoning == "thinking"
+        assert r.reasoning_blocks == blocks
+
+    def test_non_streaming_absent_reasoning_is_none(self, provider: OpenAIProvider) -> None:
+        r = provider._normalize_response(
+            _RCompletion(choices=[_RChoice(message=_RMsg(content="42"))])
+        )
+        assert r.reasoning is None
+        assert r.reasoning_blocks is None
+
+    def test_reasoning_content_alias(self, provider: OpenAIProvider) -> None:
+        """`reasoning_content` is accepted as an alias for `reasoning`."""
+        msg = _RMsg(content="42")
+        # Only the alias present (no `reasoning`); set it explicitly to empty.
+        msg.reasoning = None
+        object.__setattr__(msg, "reasoning_content", "via alias")
+        r = provider._normalize_response(_RCompletion(choices=[_RChoice(message=msg)]))
+        assert r.reasoning == "via alias"
+
+    def test_empty_reasoning_string_is_none(self, provider: OpenAIProvider) -> None:
+        r = provider._normalize_response(
+            _RCompletion(choices=[_RChoice(message=_RMsg(content="42", reasoning=""))])
+        )
+        assert r.reasoning is None
+
+    async def test_streaming_emits_reasoning_deltas_and_final(
+        self, provider: OpenAIProvider
+    ) -> None:
+        chunks = [
+            FakeChunk(choices=[FakeStreamChoice(delta=_RDelta(reasoning="I think "))]),
+            FakeChunk(choices=[FakeStreamChoice(delta=_RDelta(reasoning="therefore "))]),
+            FakeChunk(choices=[FakeStreamChoice(delta=_RDelta(content="answer"))]),
+            FakeChunk(choices=[FakeStreamChoice(delta=_RDelta(), finish_reason="stop")]),
+            FakeChunk(
+                choices=[],
+                usage=FakeChunkUsage(prompt_tokens=5, completion_tokens=2, total_tokens=7),
+            ),
+        ]
+        provider._client.chat.completions.create = AsyncMock(return_value=MockAsyncStream(chunks))
+        events = []
+        async for event in provider.complete_stream([Message(role=Role.USER, content="hi")]):
+            events.append(event)
+        deltas = [e for e in events if e.type == StreamEventType.REASONING_DELTA]
+        assert "".join(e.text for e in deltas) == "I think therefore "
+        done = next(e for e in events if e.type == StreamEventType.DONE)
+        assert done.raw.reasoning == "I think therefore "
+        assert done.raw.text == "answer"
+
+    async def test_streaming_accumulates_reasoning_blocks(self, provider: OpenAIProvider) -> None:
+        b1 = [{"type": "reasoning.encrypted", "data": "a"}]
+        b2 = [{"type": "reasoning.encrypted", "data": "b"}]
+        chunks = [
+            FakeChunk(choices=[FakeStreamChoice(delta=_RDelta(reasoning_details=b1))]),
+            FakeChunk(choices=[FakeStreamChoice(delta=_RDelta(reasoning_details=b2))]),
+            FakeChunk(choices=[FakeStreamChoice(delta=_RDelta(content="x"), finish_reason="stop")]),
+        ]
+        provider._client.chat.completions.create = AsyncMock(return_value=MockAsyncStream(chunks))
+        done = None
+        async for event in provider.complete_stream([Message(role=Role.USER, content="hi")]):
+            if event.type == StreamEventType.DONE:
+                done = event
+        assert done is not None
+        assert done.raw.reasoning_blocks == b1 + b2
+
+
+class TestReasoningReplay:
+    """Message.reasoning_blocks -> assistant `reasoning_details` on the wire."""
+
+    def test_tool_call_assistant_replays_reasoning_details(self, provider: OpenAIProvider) -> None:
+        blocks = [{"type": "reasoning.text", "text": "why", "id": "r1"}]
+        tc = ToolCall(name="add", params={"a": 1}, provider_tool_call_id="call_1")
+        msgs = [
+            Message(role=Role.USER, content="add"),
+            Message(role=Role.ASSISTANT, content="", tool_calls=[tc], reasoning_blocks=blocks),
+        ]
+        out = provider._convert_messages(msgs)
+        assert out[1]["reasoning_details"] == blocks
+        assert out[1]["tool_calls"][0]["function"]["name"] == "add"
+
+    def test_plain_assistant_replays_reasoning_details(self, provider: OpenAIProvider) -> None:
+        blocks = [{"type": "reasoning.text", "text": "x"}]
+        out = provider._convert_messages(
+            [Message(role=Role.ASSISTANT, content="ans", reasoning_blocks=blocks)]
+        )
+        assert out[0]["reasoning_details"] == blocks
+
+    def test_no_reasoning_blocks_no_details_key(self, provider: OpenAIProvider) -> None:
+        out = provider._convert_messages([Message(role=Role.ASSISTANT, content="ans")])
+        assert "reasoning_details" not in out[0]

--- a/packages/python/tests/unit/test_openai_provider.py
+++ b/packages/python/tests/unit/test_openai_provider.py
@@ -1486,6 +1486,27 @@ class TestReasoningReplay:
         )
         assert out[0]["reasoning_details"] == blocks
 
-    def test_no_reasoning_blocks_no_details_key(self, provider: OpenAIProvider) -> None:
+    def test_falls_back_to_reasoning_string(self, provider: OpenAIProvider) -> None:
+        """Raw-string-only models: replay message.reasoning when no blocks."""
+        out = provider._convert_messages(
+            [Message(role=Role.ASSISTANT, content="ans", reasoning="raw chain of thought")]
+        )
+        assert out[0]["reasoning"] == "raw chain of thought"
+        assert "reasoning_details" not in out[0]
+
+    def test_blocks_win_over_string(self, provider: OpenAIProvider) -> None:
+        blocks = [{"type": "reasoning.text", "text": "x"}]
+        out = provider._convert_messages(
+            [
+                Message(
+                    role=Role.ASSISTANT, content="ans", reasoning="ignored", reasoning_blocks=blocks
+                )
+            ]
+        )
+        assert out[0]["reasoning_details"] == blocks
+        assert "reasoning" not in out[0]
+
+    def test_no_reasoning_no_keys(self, provider: OpenAIProvider) -> None:
         out = provider._convert_messages([Message(role=Role.ASSISTANT, content="ans")])
         assert "reasoning_details" not in out[0]
+        assert "reasoning" not in out[0]

--- a/packages/python/tests/unit/test_openrouter_provider.py
+++ b/packages/python/tests/unit/test_openrouter_provider.py
@@ -30,6 +30,7 @@ from dendrux.llm.openrouter import (  # noqa: E402
     OpenRouterModel,
     OpenRouterProvider,
     _parse_model_entry,
+    _parse_reasoning,
 )
 from dendrux.types import Message, Role, StreamEventType, ToolDef, UsageStats  # noqa: E402
 
@@ -710,3 +711,223 @@ class TestUsageAccounting:
         )
         assert total.cost_usd == pytest.approx(0.003)
         assert total.cache_creation_input_tokens == 15
+
+
+# ---------------------------------------------------------------------------
+# Reasoning capability metadata
+# ---------------------------------------------------------------------------
+class TestReasoningMetadata:
+    def test_effort_based_model(self) -> None:
+        m = _parse_model_entry(
+            {
+                "id": "openai/gpt-5",
+                "supported_parameters": ["reasoning", "reasoning_effort", "tools"],
+                "reasoning": {
+                    "mandatory": True,
+                    "supported_efforts": ["high", "medium", "low", "minimal"],
+                    "default_effort": "medium",
+                },
+            }
+        )
+        assert m is not None
+        assert m.supports_reasoning
+        assert m.reasoning.mandatory
+        assert m.reasoning.supported_efforts == ("high", "medium", "low", "minimal")
+        assert m.reasoning.default_effort == "medium"
+
+    def test_budget_based_model_has_no_efforts(self) -> None:
+        """qwen3-style: reasoning supported, not mandatory, no effort list."""
+        m = _parse_model_entry(
+            {
+                "id": "qwen/qwen3-14b",
+                "supported_parameters": ["reasoning", "tools"],
+                "reasoning": {"mandatory": False},
+            }
+        )
+        assert m is not None
+        assert m.supports_reasoning
+        assert not m.reasoning.mandatory
+        assert m.reasoning.supported_efforts == ()
+        assert m.reasoning.default_effort is None
+
+    def test_no_reasoning_param_means_unsupported(self) -> None:
+        m = _parse_model_entry({"id": "x/y", "supported_parameters": ["tools"]})
+        assert m is not None
+        assert not m.supports_reasoning
+        assert not m.reasoning.mandatory
+
+    def test_reasoning_param_without_object(self) -> None:
+        caps = _parse_reasoning({"id": "x/y"}, ("reasoning",))
+        assert caps.supported
+        assert not caps.mandatory
+        assert caps.supported_efforts == ()
+
+
+# ---------------------------------------------------------------------------
+# Reasoning controls — thinking/effort → the OpenRouter reasoning block
+# ---------------------------------------------------------------------------
+class TestReasoningBlock:
+    def test_thinking_false_is_genuine_off(self) -> None:
+        # {"enabled": False} — the only payload that zeroes reasoning tokens
+        # (verified live: effort:"none" does NOT disable on Qwen3).
+        assert OpenRouterProvider._reasoning_block(False, None) == {"enabled": False}
+
+    def test_thinking_false_wins_over_effort(self) -> None:
+        assert OpenRouterProvider._reasoning_block(False, "high") == {"enabled": False}
+
+    def test_effort_passthrough(self) -> None:
+        assert OpenRouterProvider._reasoning_block(True, "medium") == {"effort": "medium"}
+        assert OpenRouterProvider._reasoning_block(None, "high") == {"effort": "high"}
+
+    def test_effort_extra_alias_maps_to_xhigh(self) -> None:
+        assert OpenRouterProvider._reasoning_block(None, "extra") == {"effort": "xhigh"}
+
+    def test_thinking_true_enables_default(self) -> None:
+        assert OpenRouterProvider._reasoning_block(True, None) == {"enabled": True}
+
+    def test_unset_leaves_request_untouched(self) -> None:
+        assert OpenRouterProvider._reasoning_block(None, None) is None
+
+
+class TestReasoningWiring:
+    async def test_constructor_reasoning_injected_into_request(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        provider = _provider(thinking=True, effort="medium")
+        captured: dict[str, Any] = {}
+
+        async def fake_create(**kwargs: Any) -> Any:
+            captured.update(kwargs)
+            return _FakeCompletion(usage=_usage())
+
+        monkeypatch.setattr(provider._client.chat.completions, "create", fake_create)
+        await provider.complete([Message(role=Role.USER, content="hi")])
+        assert captured["extra_body"]["reasoning"] == {"effort": "medium"}
+        # routing block still intact alongside reasoning
+        assert captured["extra_body"]["provider"]["require_parameters"] is True
+
+    async def test_no_reasoning_leaves_body_clean(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        provider = _provider()  # no thinking/effort
+        captured: dict[str, Any] = {}
+
+        async def fake_create(**kwargs: Any) -> Any:
+            captured.update(kwargs)
+            return _FakeCompletion(usage=_usage())
+
+        monkeypatch.setattr(provider._client.chat.completions, "create", fake_create)
+        await provider.complete([Message(role=Role.USER, content="hi")])
+        assert "reasoning" not in captured["extra_body"]
+
+    async def test_per_call_thinking_overrides_constructor(
+        self, catalog_ok: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        provider = _provider(model="deepseek/deepseek-chat", thinking=True, effort="high")
+        captured: dict[str, Any] = {}
+
+        async def fake_create(**kwargs: Any) -> Any:
+            captured.update(kwargs)
+            return _FakeCompletion(usage=_usage())
+
+        monkeypatch.setattr(provider._client.chat.completions, "create", fake_create)
+        # deepseek/deepseek-chat in CATALOG has no reasoning object → not mandatory
+        await provider.complete([Message(role=Role.USER, content="hi")], thinking=False)
+        assert captured["extra_body"]["reasoning"] == {"enabled": False}
+
+    async def test_reasoning_recorded_even_when_off_requested(
+        self, catalog_ok: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If a model reasons anyway despite thinking=False (upstream ignored the
+        disable), the tokens + text are recorded faithfully — recording reflects
+        what the model actually did and billed, never what we requested."""
+        provider = _provider(model="deepseek/deepseek-chat", thinking=False)
+        msg = _FakeMessage(content="answer")
+        msg.reasoning = "reasoned despite the off switch"  # type: ignore[attr-defined]
+        completion = _FakeCompletion(
+            choices=[_FakeChoice(message=msg)],
+            usage=_usage(completion_tokens_details={"reasoning_tokens": 42}),
+        )
+
+        async def fake_create(**kwargs: Any) -> Any:
+            # we DID send the disable directive...
+            assert kwargs["extra_body"]["reasoning"] == {"enabled": False}
+            return completion
+
+        monkeypatch.setattr(provider._client.chat.completions, "create", fake_create)
+        resp = await provider.complete([Message(role=Role.USER, content="hi")])
+        # ...but recording mirrors reality, not the request
+        assert resp.usage.reasoning_tokens == 42
+        assert resp.reasoning == "reasoned despite the off switch"
+
+
+# ---------------------------------------------------------------------------
+# Mandatory-reasoning guard
+# ---------------------------------------------------------------------------
+def _catalog_with_reasoning(model_id: str, *, mandatory: bool) -> dict[str, OpenRouterModel]:
+    entry = _parse_model_entry(
+        {
+            "id": model_id,
+            "supported_parameters": ["reasoning", "tools"],
+            "reasoning": {"mandatory": mandatory},
+        }
+    )
+    assert entry is not None
+    return {model_id: entry}
+
+
+class TestMandatoryReasoningGuard:
+    async def test_thinking_false_on_mandatory_model_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fetch = AsyncMock(return_value=_catalog_with_reasoning("x/mand", mandatory=True))
+        monkeypatch.setattr(openrouter_mod, "_fetch_catalog", fetch)
+        provider = _provider(model="x/mand", thinking=False)
+        create = AsyncMock()
+        monkeypatch.setattr(provider._client.chat.completions, "create", create)
+        with pytest.raises(ValueError, match="mandatory reasoning"):
+            await provider.complete([Message(role=Role.USER, content="hi")])
+        create.assert_not_awaited()
+
+    async def test_thinking_false_on_optional_model_proceeds(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fetch = AsyncMock(return_value=_catalog_with_reasoning("x/opt", mandatory=False))
+        monkeypatch.setattr(openrouter_mod, "_fetch_catalog", fetch)
+        provider = _provider(model="x/opt", thinking=False)
+
+        async def fake_create(**kwargs: Any) -> Any:
+            return _FakeCompletion(usage=_usage())
+
+        monkeypatch.setattr(provider._client.chat.completions, "create", fake_create)
+        result = await provider.complete([Message(role=Role.USER, content="hi")])
+        assert result is not None
+
+    async def test_mandatory_guard_only_fires_when_disabling(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """thinking=True on a mandatory model must not touch the catalog."""
+        fetch = AsyncMock(side_effect=AssertionError("catalog should not be fetched"))
+        monkeypatch.setattr(openrouter_mod, "_fetch_catalog", fetch)
+        provider = _provider(model="x/mand", thinking=True, effort="high")
+
+        async def fake_create(**kwargs: Any) -> Any:
+            return _FakeCompletion(usage=_usage())
+
+        monkeypatch.setattr(provider._client.chat.completions, "create", fake_create)
+        result = await provider.complete([Message(role=Role.USER, content="hi")])
+        assert result is not None
+
+    async def test_mandatory_guard_degrades_when_catalog_unavailable(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        monkeypatch.setattr(
+            openrouter_mod, "_fetch_catalog", AsyncMock(side_effect=ConnectionError("boom"))
+        )
+        provider = _provider(model="x/unknown", thinking=False)
+
+        async def fake_create(**kwargs: Any) -> Any:
+            return _FakeCompletion(usage=_usage())
+
+        monkeypatch.setattr(provider._client.chat.completions, "create", fake_create)
+        with caplog.at_level(logging.WARNING):
+            result = await provider.complete([Message(role=Role.USER, content="hi")])
+        assert result is not None  # never breaks a run on a metadata hiccup

--- a/packages/python/tests/unit/test_openrouter_provider.py
+++ b/packages/python/tests/unit/test_openrouter_provider.py
@@ -718,14 +718,16 @@ class TestUsageAccounting:
 # ---------------------------------------------------------------------------
 class TestReasoningMetadata:
     def test_effort_based_model(self) -> None:
+        # Mirrors OpenRouter's documented /models reasoning object shape.
         m = _parse_model_entry(
             {
-                "id": "openai/gpt-5",
+                "id": "google/gemini-3.5-flash",
                 "supported_parameters": ["reasoning", "reasoning_effort", "tools"],
                 "reasoning": {
-                    "mandatory": True,
                     "supported_efforts": ["high", "medium", "low", "minimal"],
                     "default_effort": "medium",
+                    "default_enabled": True,
+                    "mandatory": True,
                 },
             }
         )
@@ -734,14 +736,16 @@ class TestReasoningMetadata:
         assert m.reasoning.mandatory
         assert m.reasoning.supported_efforts == ("high", "medium", "low", "minimal")
         assert m.reasoning.default_effort == "medium"
+        assert m.reasoning.default_enabled is True
+        assert m.reasoning.supports_max_tokens is False  # absent → False
 
     def test_budget_based_model_has_no_efforts(self) -> None:
-        """qwen3-style: reasoning supported, not mandatory, no effort list."""
+        """qwen3-style: reasoning supported, not mandatory, token-budget based."""
         m = _parse_model_entry(
             {
                 "id": "qwen/qwen3-14b",
                 "supported_parameters": ["reasoning", "tools"],
-                "reasoning": {"mandatory": False},
+                "reasoning": {"mandatory": False, "supports_max_tokens": True},
             }
         )
         assert m is not None
@@ -749,6 +753,8 @@ class TestReasoningMetadata:
         assert not m.reasoning.mandatory
         assert m.reasoning.supported_efforts == ()
         assert m.reasoning.default_effort is None
+        assert m.reasoning.default_enabled is None
+        assert m.reasoning.supports_max_tokens is True
 
     def test_no_reasoning_param_means_unsupported(self) -> None:
         m = _parse_model_entry({"id": "x/y", "supported_parameters": ["tools"]})

--- a/packages/python/tests/unit/test_types.py
+++ b/packages/python/tests/unit/test_types.py
@@ -184,6 +184,22 @@ class TestMessageOriginEnvelope:
         assert "kind" not in d
         assert "placement" not in d
         assert "source" not in d
+        assert "reasoning" not in d
+        assert "reasoning_blocks" not in d
+
+    def test_snapshot_roundtrips_reasoning(self) -> None:
+        # Reasoning summary + replay blocks survive pause/resume so a run
+        # paused mid-tool-loop keeps its reasoning context.
+        blocks = [{"type": "reasoning.text", "text": "why", "id": "r1"}]
+        msg = Message(
+            role=Role.ASSISTANT,
+            content="ans",
+            reasoning="because",
+            reasoning_blocks=blocks,
+        )
+        restored = _message_from_dict(_message_to_dict(msg))
+        assert restored.reasoning == "because"
+        assert restored.reasoning_blocks == blocks
 
     def test_legacy_snapshot_without_envelope(self) -> None:
         # Snapshots written before PR 1 have no envelope keys — load with defaults,


### PR DESCRIPTION
Implements the OpenRouter reasoning work from **#44** (Oreo request), validated against live models and OpenRouter's [reasoning-tokens docs](https://openrouter.ai/docs/guides/best-practices/reasoning-tokens).

## What's included

**1. Reasoning capability metadata** — `OpenRouterModel.reasoning` (`OpenRouterReasoningCapabilities`) parsed from `/models`, all five documented fields: `supported` (derived), `mandatory`, `supported_efforts`, `default_effort`, `default_enabled`, `supports_max_tokens`. Enough to render Off / Low / Medium / High / Always-on and hide "Off" when disallowed.

**2. `thinking` / `effort` controls** — cross-vendor knobs → OpenRouter's `reasoning` block, constructor + per-call:
- `thinking=False` → `{"enabled": False}` (the correct disable — see caveat)
- `thinking=True, effort="medium"` → `{"effort": "medium"}`; `thinking=True` → `{"enabled": True}`

**3. Mandatory-reasoning guard** — `thinking=False` on a `mandatory` model raises before the request (docs: such models *reject* the disable), reusing the catalog + native-tools-guard infra.

**4. Reasoning-content capture + preservation** (shared OpenAI transport, inert on pure OpenAI):
- capture `message.reasoning`/`reasoning_content` → `LLMResponse.reasoning`; `reasoning_details` → `reasoning_blocks`; streaming → `reasoning_delta` events + accumulation
- replay across tool iterations: `reasoning_details` verbatim (docs: "cannot be rearranged or modified"), falling back to the plaintext `reasoning` string for raw-only models — the two preservation paths OpenRouter documents
- `Message` gains `reasoning`/`reasoning_blocks` (+ pause/resume serialization)
- public `LLMCall.reasoning` / `reasoning_tokens` already carry it — the tokens-vs-text distinction Oreo asked for

## ⚠️ Load-bearing finding from live testing

`thinking=False` sends the correct directive, **but a true zero is not guaranteed** — OpenRouter load-balances some models (e.g. qwen3-14b) across upstreams that ignore the reasoning-disable (measured 116–381 reasoning tokens even pinned to deepinfra). The docs' `effort:"none"` is worse (increased reasoning on Qwen3) and is *rejected* on mandatory models. So we send `{"enabled": False}` (best directive) and document honestly: for a hard zero, pin a compliant upstream via `extra_body`. **Recording stays faithful** — reasoning tokens/text are recorded from the response, never suppressed to match the request (locked by a test).

## Verification
- `make ci` green: ruff, ruff-format, mypy; **1669 passed** (27 new tests)
- **Live-tested** (OpenRouter + OpenAI): metadata, thinking on/off, effort, cost mapping, tool round-trips, mandatory guard, streaming, OpenAI regression — all pass

## Out of scope (noted)
`reasoning.context` / `reasoning.mode` (GPT-5.6+ Responses-API only), legacy `include_reasoning`. `supported_efforts` null-vs-omitted collapsed to `()`.

Closes #44

Authored-By: Anmol Gautam <anmolgautam2428@gmail.com>
Assisted-By: Claude <noreply@anthropic.com>