### PR TITLE
release: dendrux 0.2.0a13

### DIFF
--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dendrux"
-version = "0.2.0a12"
+version = "0.2.0a13"
 description = "The runtime for agents that act in the real world."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Release **0.2.0a13**.

## Included since 0.2.0a12
- **#45** — OpenRouter reasoning: `thinking`/`effort` controls → `reasoning` block (`enabled:false` genuine-off), mandatory-reasoning guard, `OpenRouterModel.reasoning` capability metadata, reasoning-content capture (stream + non-stream) + `reasoning_details` replay across tool iterations, faithful token/text recording.

## Version
`pyproject.toml`: `0.2.0a12` → `0.2.0a13` (single source; `__version__` via `importlib.metadata`).

## Post-merge
Manual `twine upload` by the maintainer (no CI publish). Dist will be built + `twine check`ed against this tag.

Authored-By: Anmol Gautam <anmolgautam2428@gmail.com>
Assisted-By: Claude <noreply@anthropic.com>