### PR TITLE
feat(mcp): recover dead connections and prevent reconnect storms

### DIFF
--- a/docs/architecture/mcp.mdx
+++ b/docs/architecture/mcp.mdx
@@ -1,13 +1,13 @@
 ---
 title: MCP
-description: Connect Dendrux agents to remote or subprocess MCP tools with source configuration, shared runtime ownership, policy, and auditable failure handling.
+description: Production MCP for Dendrux agents - a process-wide managed runtime with shared connections, per-tenant credentials, capacity limits, circuit breaking, clean shutdown, and operational telemetry.
 ---
 
 # MCP
 
-Model Context Protocol (MCP) servers expose tools that execute outside the agent. Dendrux is an MCP **client and host**: it discovers those external tools, converts them into normal Dendrux tools, and sends calls through the same deny, approval, guardrail, timeout, and audit pipeline as local `@tool` functions.
+Model Context Protocol (MCP) servers expose tools that execute outside the agent. Dendrux is an MCP **client and managed runtime**: it discovers those external tools, converts them into normal Dendrux tools, and sends calls through the same deny, approval, guardrail, timeout, and audit pipeline as local `@tool` functions.
 
-Dendrux does not help you build MCP servers. Use it to consume existing servers directly or through an MCP gateway.
+The recommended production path is `MCPRuntime`: one process-wide object that owns every physical MCP connection, shares them across agents and requests, isolates tenants, enforces capacity, breaks circuits on failing servers, and shuts down cleanly.
 
 Install the optional integration:
 
@@ -15,59 +15,250 @@ Install the optional integration:
 pip install "dendrux[mcp]"
 ```
 
-## Complete example: local and MCP tools
+## Who hosts the MCP servers
 
-This agent has one local Python tool and one tool from the official MCP conformance server:
+Dendrux runs MCP clients, never remote MCP servers itself:
+
+- **Remote HTTP servers** are hosted by their vendor (a SaaS MCP endpoint), by your platform team, or behind an MCP gateway you deploy. Dendrux connects to them over streamable HTTP.
+- **Stdio servers** are subprocesses that Dendrux spawns on your machine, with your process's operating-system privileges. You own what they can touch. MCP is not a sandbox: run only trusted stdio servers directly, and put untrusted ones in a container or isolated MCP server or gateway reached over HTTP.
+- Dendrux does not help you build MCP servers. Use the official MCP SDKs for that, then consume the result from Dendrux.
+
+Pin subprocess package versions, as these examples do, instead of executing an unreviewed future `latest` release.
+
+## The recommended path
 
 ```python
 import asyncio
 
-from dendrux import Agent, tool
-from dendrux.mcp import MCPHost, MCPSource
-
-
-@tool()
-async def count_words(text: str) -> dict[str, int]:
-    """Count the words in a piece of text."""
-    return {"word_count": len(text.split())}
+from dendrux import Agent
+from dendrux.mcp import MCPRuntime, MCPSource
 
 
 async def main() -> None:
-    everything = MCPSource.stdio(
-        name="everything",
-        command=["npx", "-y", "@modelcontextprotocol/server-everything@2026.7.4"],
-        connect_timeout=60,  # allows a cold first-run npx download
-        call_timeout=30,
-        max_result_bytes=100_000,
+    runtime = MCPRuntime()  # one per worker event loop, at startup
+
+    connection = runtime.bind(
+        connection_key="github-1",
+        source=MCPSource.http(
+            name="github",
+            url="https://mcp.example.com/github",
+            headers={"Authorization": "Bearer ..."},
+        ),
     )
 
-    async with MCPHost([everything]) as mcp_host:
-        async with Agent(
-            provider="anthropic:claude-haiku-4-5",
-            prompt="Use the echo and count_words tools when requested.",
-            tools=[count_words],
-            tool_sources=[mcp_host],
-        ) as agent:
-            result = await agent.run(
-                "Echo 'Dendrux uses MCP tools safely', then count its words."
-            )
-            print(result.answer)
+    async with Agent(
+        provider="anthropic:claude-haiku-4-5",
+        prompt="Help maintain the repository.",
+        tool_sources=[connection.tools()],
+    ) as agent:
+        result = await agent.run("List my open issues.")
+        print(result.answer)
+
+    await runtime.close()  # application shutdown, not per request
 
 
 asyncio.run(main())
 ```
 
-Prerequisites are Node.js with `npx`, an Anthropic API key, and `dendrux[anthropic,mcp]`. The complete runnable version is [`packages/python/examples/30_mcp_agent.py`](https://github.com/dendrux/dendrux/blob/main/packages/python/examples/30_mcp_agent.py).
+Construction, `bind()`, and `tools()` are synchronous, perform no I/O, and resolve no credentials. The physical connection opens lazily on the first tool discovery and is then shared: a second agent bound to the same key reuses the live connection instead of opening its own.
 
-## The three objects
+## The objects
 
 | Object | Responsibility | Typical lifetime |
 | --- | --- | --- |
 | `MCPSource` | Immutable connection, authentication, and limit configuration. | Application configuration. |
-| `MCPHost` | Owns SDK connections and discovered catalogs so multiple agents can share them safely. | One worker, tenant, or credential identity. |
-| `MCPServer` | Backward-compatible facade used by the runtime. Existing `MCPServer(...)` code still works. | Prefer `MCPSource` in new code. |
+| `MCPRuntime` | Event-loop-affine owner of physical connections, capacity, circuits, and telemetry. | Normally one per worker process, closed at shutdown. |
+| `MCPConnection` | Lazy handle for one `(tenant_key, connection_key)` identity returned by `bind()`. | Cheap; re-bind per request if convenient. |
+| `MCPToolView` | Namespace and tool policy one agent consumes via `tool_sources`. | One per agent. |
+| `MCPHost` / `MCPServer` | Simpler facades that predate the runtime. Still supported. | Scripts, notebooks, single-agent tools. |
 
 The official MCP Python SDK owns protocol framing, transport negotiation, and the underlying client session. Dendrux owns agent-facing names, lifecycle policy, result boundaries, governance, and evidence.
+
+## Process-local ownership
+
+`MCPRuntime` is the MCP equivalent of a database connection pool. It is deliberately process-local and event-loop-affine: no database, no coordination between workers, no shared state beyond the process boundary. A conventional async worker has one event loop and creates one runtime at startup. If your process deliberately runs multiple event loops, create one runtime per loop. Capacity limits and telemetry describe that runtime only.
+
+This matches how connection pools are operated: a deployment with four workers and `max_connections=100` can hold up to 400 physical MCP connections in total, and each worker reports its own snapshot. The [RunStore](/docs/architecture/runs) remains the durable, cross-process record of what agents did; the runtime is the live, in-memory record of what connections are doing right now.
+
+```python
+runtime = MCPRuntime(
+    max_connections=100,       # physical connections across all tenants
+    max_in_flight_calls=100,   # concurrently executing MCP tool calls
+    idle_timeout=300.0,        # retire connections unused this long (None keeps them warm)
+    connection_wait_timeout=10.0,  # queue wait for a connection slot; 0 fails fast
+    call_wait_timeout=10.0,        # queue wait for a call slot; 0 sheds load immediately
+    shutdown_timeout=30.0,     # drain budget before close() interrupts work
+    circuit_failure_threshold=5,   # consecutive connect failures before fail-fast (None disables)
+    circuit_reset_timeout=30.0,    # cooldown before one probe connection is allowed
+)
+```
+
+## Identities and tenants
+
+Every managed connection is addressed by `(tenant_key, connection_key)`:
+
+```python
+connection = runtime.bind(
+    connection_key="github-1",
+    tenant_key=user_id,       # omit for single-tenant applications
+    source=github_source,
+    credentials=provider,
+)
+```
+
+Two tenants bound to the same endpoint get two physical connections. The runtime never merges authentication contexts: a tenant's tools always execute over a transport established with that tenant's credentials. Circuit state, eviction, connection identity, and telemetry are partitioned by `(tenant_key, connection_key)`, so one tenant's failing server opens only that tenant's circuit.
+
+Connection and call capacity are intentionally **process-wide budgets**, not per-tenant quotas. FIFO queues and bounded wait timeouts prevent indefinite starvation, but one noisy tenant can still add bounded latency for others. Applications that need contractual per-tenant quotas should enforce them before invoking the runtime.
+
+Binding is cheap and idempotent for equivalent configuration, so a web handler can call `bind()` on every request. Rebinding the same key with a *different* endpoint or transport raises `MCPBindingConflictError`; changing configuration for a live connection requires an eviction first.
+
+## Credentials
+
+Static headers work for shared secrets. For per-tenant or expiring credentials, pass a provider:
+
+```python
+class TenantTokens:
+    def __init__(self, tenant_id: str) -> None:
+        self.tenant_id = tenant_id
+
+    async def get_auth(self) -> dict[str, str]:
+        token = await fetch_token(self.tenant_id)   # your secret store
+        return {"Authorization": f"Bearer {token}"}
+
+
+connection = runtime.bind(
+    connection_key="github-1",
+    tenant_key=tenant_id,
+    source=github_source,
+    credentials=TenantTokens(tenant_id),
+)
+```
+
+The provider is called lazily, once per *physical connection attempt* — never per agent or per tool call. A connection retired between requests may therefore resolve credentials again on the next request. Its result establishes that one transport (request headers for HTTP, environment variables for stdio) and remains only in that connection's in-memory, connect-scoped configuration for the physical connection lifetime; it is never persisted, logged, or rendered into errors. Because the runtime knows the exact secret strings, it scrubs them from any transport or tool error text before that text can reach the run store or the model. Opaque auth objects are rejected at `bind()` for the same reason: their secret values cannot be enumerated for redaction.
+
+To rotate credentials explicitly, pass a stable non-secret `credential_identity` (a credential row id, a rotation counter). Rebinding with a new identity conflicts while the old connection is live — evict first — and supersedes older handles once it is not. Without it, the newest bind's provider is simply consulted at the next physical connect.
+
+## Views and tool policy
+
+`connection.tools()` returns the object an agent consumes. It selects and names tools without touching the network:
+
+```python
+view = connection.tools(
+    namespace="gh",                          # default: the source name
+    allowed_tools=["read_file", "create_issue"],  # default: every server tool
+    force_serial_tools=["create_issue"],     # never run concurrently
+)
+
+agent = Agent(provider=provider, prompt=..., tool_sources=[view])
+```
+
+MCP tools are exposed as `namespace__tool_name` (`gh__create_issue`); characters outside the portable provider subset become `_`, and the final name must be at most 64 characters. Use the namespaced name in deny and approval rules:
+
+```python
+agent = Agent(
+    provider=provider,
+    prompt="Help maintain the repository.",
+    tool_sources=[view],
+    deny=["gh__delete_repo"],
+    require_approval=["gh__create_issue"],
+)
+```
+
+Exposing every server tool (the no-argument default) is an explicit governance decision; prefer `allowed_tools` allowlists in production. MCP tool annotations are advisory: Dendrux schedules an MCP tool concurrently only when it is explicitly marked read-only and not destructive; everything else runs serially.
+
+## Sizing
+
+Size the runtime like a connection pool:
+
+- **`max_connections`** bounds physical connections, which map one-to-one to bound identities in active use. Estimate it as *concurrently active tenants x sources per tenant*, plus headroom. Idle retirement (`idle_timeout`) returns slots from tenants that went quiet; set it to `None` for stdio servers whose subprocess startup costs more than holding the connection warm.
+- **`max_in_flight_calls`** bounds concurrently executing tool calls process-wide, protecting your process and the servers behind it. Agents rarely need more than a few calls in flight each; start near your worker's realistic agent concurrency.
+- **The wait timeouts** decide queueing behaviour at the two capacity boundaries. Non-zero values absorb bursts; `0` fails fast (`MCPConnectionCapacityError`) or sheds load (`MCPCallCapacityError`) immediately. Both errors are transient and never mean the tool call was sent.
+- Multiply everything by worker count when budgeting against server-side rate limits — each process enforces its own limits.
+
+Watch `snapshot().connection_waiters` and `call_waiters` in production: persistent waiters mean the limits are too tight or a server is too slow.
+
+## Failure handling
+
+- **Connect failures** count toward a per-identity circuit breaker. After `circuit_failure_threshold` consecutive failures, new connection attempts fail fast with `MCPCircuitOpenError` (carrying `retry_after`) instead of hammering a dead server. After `circuit_reset_timeout`, one probe connection is allowed through; success closes the circuit, failure re-arms it. A tenant's broken sandbox cannot consume the whole process's capacity retrying.
+- **Transport loss mid-call** fences the dead connection so no new work routes to it, and interrupted calls raise `MCPOutcomeUnknownError`: the server may already have applied the call, so Dendrux never retries it automatically. The next lease opens a fresh connection.
+- **Ordinary tool errors** (`MCPToolCallError`) are just results: the model reads the redacted error text and corrects itself. They never poison the shared connection.
+
+To remove a connection deliberately — a tenant offboarded, credentials revoked, an endpoint migrated:
+
+```python
+await runtime.evict(connection_key="github-1", tenant_key=user_id)          # drain, then close
+await runtime.evict(connection_key="github-1", tenant_key=user_id, mode="force")  # fence immediately
+```
+
+Draining waits for active calls; force interrupts them (`MCPOutcomeUnknownError`). Afterwards the key may be rebound with new configuration.
+
+## Shutdown
+
+```python
+await runtime.close()
+```
+
+`close()` stops new leases and calls, waits up to `shutdown_timeout` for active work to drain, force-evicts whatever remains, and closes every transport. It is idempotent and safe to call concurrently. A transport that resists closing is abandoned to bounded background cleanup rather than hanging your shutdown. `MCPRuntime` is also an async context manager (`async with MCPRuntime() as runtime:`) when your application frame is a single scope.
+
+Closing an *agent* never closes runtime connections — it only releases that agent's lease. The runtime is the single owner of every physical connection.
+
+## Operational telemetry
+
+The runtime answers "what is happening right now" without any storage. `snapshot()` is synchronous, thread-safe, and cheap — call it from a metrics scraper thread on an interval (poll it, don't spin on it):
+
+```python
+snapshot = runtime.snapshot()
+snapshot.connections          # per-connection status, leases, active calls
+snapshot.in_flight_calls      # admitted calls occupying capacity
+snapshot.connection_waiters   # callers queued for a connection slot
+snapshot.call_waiters         # callers queued for a call slot
+snapshot.open_circuits        # identities currently failing fast
+```
+
+For events — connections opening and closing, circuits opening, capacity rejections, tool call outcomes — pass an observer and bridge to Prometheus, OpenTelemetry, Datadog, or logs:
+
+```python
+class Metrics:
+    def on_event(self, event) -> None:   # sync, fast, never raises into the runtime
+        EVENT_COUNTER.labels(type(event).__name__).inc()
+
+runtime = MCPRuntime(observer=Metrics())
+```
+
+Events are immutable, typed, and value-free by construction: identities, class names, counts, and durations — never credentials, URLs, tool arguments, results, or error text. Observer exceptions are swallowed and logged without detail; telemetry can never break MCP work.
+
+## Complete example: multi-user agents on one runtime
+
+One process serves two users. Each gets their own tenant partition, workspace, and credentials over the same runtime:
+
+```python
+runtime = MCPRuntime(max_connections=10, max_in_flight_calls=8)
+
+async def serve(user_id: str, workspace: Path, question: str) -> str:
+    connection = runtime.bind(
+        connection_key="filesystem",
+        tenant_key=user_id,
+        source=MCPSource.stdio(
+            name="filesystem",
+            command=["npx", "-y", "@modelcontextprotocol/server-filesystem@2026.7.4", str(workspace)],
+        ),
+    )
+    async with Agent(
+        provider="anthropic:claude-haiku-4-5",
+        prompt="You are this user's filesystem assistant.",
+        tool_sources=[connection.tools(allowed_tools=["list_directory", "read_text_file"])],
+    ) as agent:
+        result = await agent.run(question)
+        return result.answer
+
+answers = await asyncio.gather(
+    serve("user-a", alice_dir, "What files do I have?"),
+    serve("user-b", bob_dir, "Summarize notes.txt."),
+)
+await runtime.close()
+```
+
+The complete runnable version — concurrent users, fresh agents reusing warm connections, a telemetry observer, a post-request snapshot, and graceful shutdown — is [`packages/python/examples/31_mcp_runtime_multi_user.py`](https://github.com/dendrux/dendrux/blob/main/packages/python/examples/31_mcp_runtime_multi_user.py).
 
 ## Configure an HTTP source
 
@@ -87,7 +278,7 @@ github = MCPSource.http(
 )
 ```
 
-`auth=` accepts an authentication object supported by the MCP SDK's `httpx2.AsyncClient`, including an SDK OAuth provider. Prefer `headers=` or `auth=` over credentials embedded in a URL; Dendrux rejects credential-bearing URLs.
+Prefer `headers=` or a credential provider over credentials embedded in a URL; Dendrux rejects credential-bearing URLs. Unmanaged use (`MCPHost`, direct sources) additionally accepts `auth=` objects supported by the MCP SDK's HTTP client; the managed runtime rejects opaque auth objects because their secrets cannot be redacted.
 
 ## Configure a stdio source
 
@@ -108,58 +299,16 @@ filesystem = MCPSource.stdio(
 )
 ```
 
-The subprocess runs with the Dendrux process's operating-system privileges. MCP is not a sandbox. Only run trusted stdio servers directly; put untrusted servers in a container or isolated MCP runtime and connect over HTTP.
-
-Pin subprocess package versions, as these examples do, instead of executing an unreviewed future `latest` release.
-
-## Simple ownership versus shared ownership
-
-For one short-lived agent, pass a source directly. The agent owns and closes the connection:
-
-```python
-async with Agent(
-    provider=provider,
-    prompt="You are a filesystem assistant.",
-    tool_sources=[filesystem],
-) as agent:
-    result = await agent.run("List the workspace files.")
-```
-
-For a web worker or multiple agents, use `MCPHost`:
-
-```python
-host = MCPHost([github, filesystem])
-
-researcher = Agent(
-    provider=research_provider,
-    prompt="Research the codebase.",
-    tool_sources=[host],
-)
-
-reviewer = Agent(
-    provider=review_provider,
-    prompt="Review code changes.",
-    tool_sources=[host],
-)
-
-await researcher.close()  # does not close host connections
-await reviewer.close()
-await host.close()        # application shutdown
-```
-
-Create separate hosts for different tenants or credential identities. A host deliberately never merges authentication contexts.
+The subprocess runs with the Dendrux process's operating-system privileges — see [who hosts the MCP servers](#who-hosts-the-mcp-servers).
 
 ## Discovery and catalog lifetime
 
-`MCPSource` and `MCPHost` construction perform no network or subprocess I/O. Discovery happens lazily when `agent.run()` or `agent.get_tool_lookups()` first needs the tools.
+Configuration, binding, and view creation perform no network or subprocess I/O. Discovery happens lazily when `agent.run()` or `agent.get_tool_lookups()` first needs the tools:
 
 - Every paginated `tools/list` page is collected.
-- The agent receives a stable catalog for its lifetime.
-- An `MCPHost` caches each source catalog across its agents.
-- `await agent.refresh()` clears a directly owned agent catalog.
-- For a shared host, call `await host.refresh()` between runs, then `await agent.refresh()` for each reused agent that needs the new snapshot.
-
-Do not refresh while a run is active or paused. A run should execute against one stable capability set.
+- The agent receives a stable catalog for its lifetime; a run executes against one capability set.
+- Catalogs belong to the physical connection: agents sharing a live managed connection share its catalog, and a reconnect (after idle retirement, transport loss, or eviction) rediscovers fresh.
+- To force rediscovery of a managed connection deliberately, evict it; the next agent reconnects and rediscovers. For unmanaged owners, `await agent.refresh()` and `await host.refresh()` remain available.
 
 You can force discovery during application startup for a health check:
 
@@ -168,48 +317,9 @@ lookups = await agent.get_tool_lookups()
 print(sorted(lookups.fn))
 ```
 
-## Tool names and policy
-
-MCP tools are exposed as `source_name__tool_name`:
-
-```text
-github + create_issue  -> github__create_issue
-filesystem + read_file -> filesystem__read_file
-```
-
-Namespacing prevents cross-server and local-tool collisions. Characters outside the portable provider subset are converted to `_`; the final name must be at most 64 characters.
-
-Use the namespaced name in Dendrux policy:
-
-```python
-agent = Agent(
-    provider=provider,
-    prompt="Help maintain the repository.",
-    tool_sources=[host],
-    deny=["filesystem__delete_file"],
-    require_approval=["github__create_issue"],
-)
-```
-
-MCP tool annotations are advisory. Dendrux schedules an MCP tool concurrently only when it is explicitly marked read-only and not destructive; tools without those annotations run serially.
-
-## Failure modes
+## Failure modes at discovery
 
 Each source chooses how discovery failure affects the run:
-
-```python
-required = MCPSource.http(
-    "payments",
-    "https://payments.example.com/mcp",
-    failure_mode="strict",
-)
-
-optional = MCPSource.http(
-    "analytics",
-    "https://analytics.example.com/mcp",
-    failure_mode="best_effort",
-)
-```
 
 | Mode | Behaviour |
 | --- | --- |
@@ -220,7 +330,7 @@ A successful source emits `mcp.connected` with its source name, tool count, and 
 
 ## Calls, errors, and result limits
 
-MCP calls pass through the ordinary Dendrux server-tool execution path. That means deny rules, approval pauses, guardrails, call limits, timeouts, persisted tool calls, and completion/error events work the same way as for local tools.
+MCP calls pass through the ordinary Dendrux server-tool execution path: deny rules, approval pauses, guardrails, call limits, timeouts, persisted tool calls, and completion/error events work the same way as for local tools.
 
 The integration preserves:
 
@@ -229,7 +339,33 @@ The integration preserves:
 - image, audio, resource-link, and embedded-resource blocks in a JSON content envelope;
 - negotiated protocol version and server identity in `ToolDef.meta`.
 
-`max_result_bytes` is enforced before a result enters the model conversation. An oversized result raises `MCPResultTooLargeError`; unsuccessful MCP results raise `MCPToolCallError`; connection failures raise `MCPConnectionError`.
+`max_result_bytes` is enforced before a result enters the model conversation. Errors an application should be ready to handle:
+
+| Error | Meaning | Was anything sent? |
+| --- | --- | --- |
+| `MCPToolCallError` | An admitted tool call failed; some local lifecycle rejections also use this base type. | Usually. Do not infer delivery from this base type alone. |
+| `MCPOutcomeUnknownError` | The call was interrupted; the server may have applied it. | Maybe — never retry automatically. |
+| `MCPCircuitOpenError` | Connect attempts are failing fast; carries `retry_after`. | No. |
+| `MCPConnectionCapacityError` / `MCPCallCapacityError` | Capacity limit reached within the wait budget. | No. |
+| `MCPConnectionError` | The connection could not be established. | No. |
+| `MCPResultTooLargeError` | The result exceeded `max_result_bytes`. | Yes — the result was discarded. |
+
+All are subclasses of `MCPError`, importable from `dendrux.mcp`.
+
+## Simple ownership without the runtime
+
+For a script or notebook with one short-lived agent, pass a source directly; the agent owns and closes the connection:
+
+```python
+async with Agent(
+    provider=provider,
+    prompt="You are a filesystem assistant.",
+    tool_sources=[filesystem],
+) as agent:
+    result = await agent.run("List the workspace files.")
+```
+
+`MCPHost` remains a middle ground — application-owned connections shared across a few agents, without tenancy, capacity, circuits, or telemetry — and `MCPServer(...)` code keeps working. New multi-user or long-running services should use `MCPRuntime`.
 
 ## Configuration reference
 
@@ -245,9 +381,11 @@ Common options on `MCPSource.http(...)` and `MCPSource.stdio(...)`:
 
 HTTP-only options are `url`, `headers`, and `auth`. Stdio-only options are `command`, `env`, and `cwd`; mixing transport-specific options raises `ValueError` during construction.
 
+`MCPRuntime` constructor options are listed under [process-local ownership](#process-local-ownership).
+
 ## Where this fits
 
-- [`Agent.tool_sources`](/docs/reference/agent#constructor) attaches sources or hosts.
+- [`Agent.tool_sources`](/docs/reference/agent#constructor) attaches views, sources, or hosts.
 - [Access control](/docs/architecture/access-control) denies namespaced tools deterministically.
 - [Approval](/docs/architecture/approval) pauses before sensitive MCP calls.
-- [Web endpoint recipe](/docs/recipes/web-endpoint) shows worker-scoped host ownership.
+- [Web endpoint recipe](/docs/recipes/web-endpoint) shows runtime ownership in a worker process.

--- a/docs/recipes/web-endpoint.mdx
+++ b/docs/recipes/web-endpoint.mdx
@@ -23,59 +23,71 @@ Building the `Agent` object is essentially free. The cost is in the resources it
 | Resource | Cost if rebuilt per request | What to do |
 | --- | --- | --- |
 | DB engine | A new connection pool every request | Share one: set `DENDRUX_DATABASE_URL` or inject a `state_store`. |
-| MCP source | Re-spawns a subprocess / reconnects + re-lists tools | Share an application-owned `MCPHost` scoped to one tenant/credential identity. |
-| Provider client | Loses connection keep-alive | Optional: pool by `(vendor, model)`. |
+| MCP source | Re-spawns a subprocess / reconnects + re-lists tools | Share one process-wide `MCPRuntime`; `bind()` per request with the requester's `tenant_key`. |
+| Provider client | Loses connection keep-alive | Use a request-owned provider unless your application has an explicit non-Agent owner for a shared provider. |
 
 ```python
 # ---- once per worker (startup) ----
 from dendrux.db.session import get_engine
-from dendrux.mcp import MCPHost, MCPSource
+from dendrux.mcp import MCPRuntime, MCPSource
 from dendrux.runtime.state import SQLAlchemyStateStore
 
 engine = await get_engine(os.environ["DENDRUX_DATABASE_URL"])  # shared singleton
 STORE  = SQLAlchemyStateStore(engine)
-MCP_HOSTS = {
-    "github": MCPHost([
-        MCPSource.http(
-            "github",
-            os.environ["GITHUB_MCP_URL"],
-            headers={"Authorization": f"Bearer {os.environ['GITHUB_MCP_TOKEN']}"},
-        )
-    ])
+MCP_RUNTIME = MCPRuntime()                                     # one per worker process
+MCP_SOURCES = {
+    "github": MCPSource.http(
+        "github",
+        os.environ["GITHUB_MCP_URL"],
+    )
 }
-PROVIDERS = {}   # (vendor, model) -> provider
+
+class GitHubCredentials:
+    def __init__(self, user_id: str) -> None:
+        self.user_id = user_id
+
+    async def get_auth(self) -> dict[str, str]:
+        # Your application owns encrypted storage, refresh, and authorization.
+        token = await credential_store.github_access_token(self.user_id)
+        return {"Authorization": f"Bearer {token}"}
 
 # ---- per request ----
 @app.post("/chat")
 async def chat(req):
-    agent = Agent(
-        provider=PROVIDERS[(req.vendor, req.model)],
+    views = [
+        MCP_RUNTIME.bind(                       # synchronous, no I/O; cheap per request
+            connection_key=m,
+            tenant_key=req.user_id,             # per-tenant connections and credentials
+            source=MCP_SOURCES[m],
+            credentials=GitHubCredentials(req.user_id),
+        ).tools()
+        for m in req.enabled_mcps
+    ]
+    async with Agent(
+        provider=f"{req.vendor}:{req.model}",             # request-owned provider
         prompt=req.system_prompt,
         tools=[TOOLS[t] for t in req.enabled_tools],          # current selection
-        tool_sources=[MCP_HOSTS[m] for m in req.enabled_mcps], # shared leases
+        tool_sources=views,                                   # shared runtime leases
         state_store=STORE,                                    # shared engine
-    )
-    result = await agent.run(
-        req.text,
-        history=req.transcript,                               # your app owns this
-        metadata={"thread_id": req.thread_id},
-    )
-    return {"answer": result.answer}
+    ) as agent:
+        result = await agent.run(
+            req.text,
+            history=req.transcript,                           # your app owns this
+            metadata={"thread_id": req.thread_id},
+        )
+        return {"answer": result.answer}
 ```
 
 ### Ownership at request shutdown
 
-`MCPHost` makes MCP ownership explicit: `agent.close()` only releases the agent's host leases and does not close shared MCP connections. The application closes the host during worker shutdown.
+`MCPRuntime` makes MCP ownership explicit: `agent.close()` releases the agent's MCP leases but does not close shared MCP connections. Always close every request-scoped Agent (the `async with` above guarantees it), or its lease can pin a connection and delay runtime shutdown. The runtime keeps each tenant's connection warm for the next request, retires it after `idle_timeout`, and the application closes the runtime during worker shutdown. See [MCP](/docs/architecture/mcp) for tenancy, credentials, capacity, and telemetry.
 
-The provider in this example is also pooled, so do not call `agent.close()` per request because it would close that provider. Either let the lightweight Agent be garbage-collected, give each request its own provider, or manage provider ownership separately. Close all application-owned pools at worker shutdown:
+An Agent owns and closes the provider passed to it, so this example uses a provider recipe string to create one per request. Do not hand an Agent a shared provider unless your application has deliberately coordinated that provider's ownership outside the Agent lifecycle. Close application-owned pools at worker shutdown:
 
 ```python
 @app.on_event("shutdown")
 async def shutdown():
-    for host in MCP_HOSTS.values():
-        await host.close()
-    for provider in PROVIDERS.values():
-        await provider.close()
+    await MCP_RUNTIME.close()   # drains active MCP work, closes every transport
 ```
 
 ### Shortcut for simple scripts: a provider recipe string

--- a/docs/reference/agent.mdx
+++ b/docs/reference/agent.mdx
@@ -31,7 +31,7 @@ Agent(
     prompt: str,
     name: str = ...,                       # defaults to the class name
     tools: list[Callable] = [],
-    tool_sources: list[MCPSource | MCPServer | MCPHost] | None = None,
+    tool_sources: list[MCPToolView | MCPSource | MCPServer | MCPHost] | None = None,
     max_iterations: int = 10,
     max_delegation_depth: int | None = None,
     loop: Loop | None = None,              # defaults to ReActLoop
@@ -153,7 +153,7 @@ Start a fresh run that reuses an existing terminal run's input and approximate p
 async def close() -> None
 ```
 
-Close directly owned MCP sources, the provider, and any agent-owned engine. Called for you by `async with Agent(...)`. `MCPHost` leases do not close the application-owned host; close the host separately at worker shutdown. The shared global engine from `DENDRUX_DATABASE_URL` is not disposed because it is not agent-owned.
+Close directly owned MCP sources, the provider, and any agent-owned engine. Called for you by `async with Agent(...)`. Leases on shared MCP connections (`MCPRuntime` views, `MCPHost`) are released, never closed; the application closes its runtime or host at worker shutdown. The shared global engine from `DENDRUX_DATABASE_URL` is not disposed because it is not agent-owned.
 
 ## Where this fits
 

--- a/docs/reference/api-glossary.mdx
+++ b/docs/reference/api-glossary.mdx
@@ -75,8 +75,13 @@ Caching is automatic for all built-in providers. See [Prompt cache](/docs/archit
 
 | Symbol | Import | What it is |
 | --- | --- | --- |
-| `MCPSource` | `from dendrux.mcp import MCPSource` | Immutable HTTP or stdio source configuration for `tool_sources=`. See [MCP](/docs/architecture/mcp). |
-| `MCPHost` | `from dendrux.mcp import MCPHost` | Application-owned MCP connections and catalogs shared safely across agents. |
+| `MCPSource` | `from dendrux.mcp import MCPSource` | Immutable HTTP or stdio source configuration. See [MCP](/docs/architecture/mcp). |
+| `MCPRuntime` | `from dendrux.mcp import MCPRuntime` | Process-wide managed owner of MCP connections: tenancy, capacity, circuit breaking, telemetry. Recommended for production. |
+| `MCPConnection` | `runtime.bind(...)` | Lazy handle for one `(tenant_key, connection_key)` identity; `connection.tools()` creates agent views. |
+| `MCPToolView` | `connection.tools(...)` | Namespace and tool policy one agent consumes via `tool_sources=`. |
+| `MCPCredentialProvider` | `from dendrux.mcp import MCPCredentialProvider` | Async protocol returning per-connect authentication (headers or env); resolved lazily, never persisted. |
+| `MCPRuntimeObserver` | `from dendrux.mcp import MCPRuntimeObserver` | Sync callback protocol receiving typed runtime lifecycle events; pair with `runtime.snapshot()`. |
+| `MCPHost` | `from dendrux.mcp import MCPHost` | Application-owned connections shared across a few agents, without tenancy or capacity; prefer `MCPRuntime` in services. |
 | `MCPServer` | `from dendrux.mcp import MCPServer` | Backward-compatible source facade; prefer `MCPSource` in new code. |
 
 ## Result and event types

--- a/docs/reference/errors.mdx
+++ b/docs/reference/errors.mdx
@@ -43,6 +43,10 @@ A few related exceptions live on the package root rather than `dendrux.errors`:
 | `StructuredOutputValidationError` | A SingleCall `output_type` fails validation. |
 | `DelegationDepthExceededError` | A sub-agent exceeds `max_delegation_depth`. |
 
+## MCP errors
+
+MCP tool sources raise their own typed hierarchy under `MCPError`, importable from `dendrux.mcp`. The ones an application should be ready to handle — including `MCPCircuitOpenError` (fail-fast with `retry_after`), the capacity errors, and `MCPOutcomeUnknownError` (interrupted call the server may have applied; never retry automatically) — are tabulated with their semantics on the [MCP page](/docs/architecture/mcp#calls-errors-and-result-limits).
+
 ## Example: mapping errors in a write route
 
 ```python

--- a/packages/python/examples/30_mcp_agent.py
+++ b/packages/python/examples/30_mcp_agent.py
@@ -1,8 +1,10 @@
-"""MCP + local tools — one agent, one shared production lifecycle.
+"""MCP + local tools — the simple, single-process path.
 
 The agent combines a regular Dendrux ``@tool`` with ``echo`` from the
 official MCP conformance server. ``MCPSource`` describes the external tool
-source; ``MCPHost`` owns its connection and discovered catalog.
+source; ``MCPHost`` owns its connection and discovered catalog. For a
+multi-user service — shared connections, tenants, capacity, telemetry —
+see ``31_mcp_runtime_multi_user.py``.
 
 Prerequisites:
     - Node.js + npx

--- a/packages/python/examples/31_mcp_runtime_multi_user.py
+++ b/packages/python/examples/31_mcp_runtime_multi_user.py
@@ -1,0 +1,153 @@
+"""Multi-user MCP — one process-wide runtime serving isolated tenants.
+
+Two users share one ``MCPRuntime``. Each gets a private tenant partition
+keyed by ``(tenant_key, connection_key)``: their own filesystem server
+subprocess rooted at their own workspace, established with their own
+lazily resolved credentials. The runtime owns every physical connection;
+agents only lease them. Two request rounds demonstrate that fresh agents
+reuse those connections. A telemetry observer and post-request snapshot
+show what the runtime is doing, and one ``close()`` drains everything.
+
+Prerequisites:
+    - Node.js + npx
+    - ANTHROPIC_API_KEY in the repository-root .env or environment
+    - ``pip install "dendrux[anthropic,mcp]"``
+
+Run from ``packages/python``:
+    python examples/31_mcp_runtime_multi_user.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from collections import Counter
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from dendrux import Agent
+from dendrux.mcp import MCPRuntime, MCPRuntimeEvent, MCPSource
+
+load_dotenv(Path(__file__).resolve().parents[3] / ".env")
+
+
+class EventCounter:
+    """Bridge runtime lifecycle events to your metrics system.
+
+    Events are typed, immutable, and value-free: identities, class names,
+    counts, and durations — never credentials, arguments, or results.
+    """
+
+    def __init__(self) -> None:
+        self.counts: Counter[str] = Counter()
+
+    def on_event(self, event: MCPRuntimeEvent) -> None:
+        self.counts[type(event).__name__] += 1
+
+
+class TenantEnvironment:
+    """Per-tenant credentials, resolved once per physical connection.
+
+    In production this would fetch a token from your secret store. The
+    resolved mapping only establishes the transport (environment variables
+    for stdio, headers for HTTP) and is never persisted or logged.
+    """
+
+    def __init__(self, user_id: str) -> None:
+        self.user_id = user_id
+
+    async def get_auth(self) -> dict[str, str]:
+        return {"DENDRUX_EXAMPLE_USER": self.user_id}
+
+
+def seed_workspace(workspace: Path, note: str) -> None:
+    (workspace / "notes.txt").write_text(note)
+
+
+async def serve_user(runtime: MCPRuntime, user_id: str, workspace: Path) -> str:
+    """One request handler: bind, lease through an agent, answer."""
+    # bind() is synchronous, performs no I/O, and is cheap to repeat per
+    # request. The physical connection opens on first tool discovery and
+    # is reused by every later agent for this tenant.
+    connection = runtime.bind(
+        connection_key="filesystem",
+        tenant_key=user_id,
+        source=MCPSource.stdio(
+            name="filesystem",
+            command=[
+                "npx",
+                "-y",
+                "@modelcontextprotocol/server-filesystem@2026.7.4",
+                str(workspace),
+            ],
+            connect_timeout=60,  # allows a cold first-run npx download
+            call_timeout=30,
+        ),
+        credentials=TenantEnvironment(user_id),
+    )
+
+    async with Agent(
+        provider="anthropic:claude-haiku-4-5",
+        prompt=(
+            "You are this user's private filesystem assistant. "
+            "Use the filesystem tools to answer from their workspace."
+        ),
+        # Allowlisting tools is an explicit governance decision.
+        tool_sources=[connection.tools(allowed_tools=["list_directory", "read_text_file"])],
+        max_iterations=6,
+    ) as agent:
+        result = await agent.run("Read notes.txt and repeat its exact contents.")
+        return result.answer or ""
+
+
+async def main() -> None:
+    observer = EventCounter()
+    with (
+        tempfile.TemporaryDirectory(prefix="dendrux_user_a_") as alice_directory,
+        tempfile.TemporaryDirectory(prefix="dendrux_user_b_") as bob_directory,
+    ):
+        workspaces = {
+            "user-a": Path(alice_directory),
+            "user-b": Path(bob_directory),
+        }
+        seed_workspace(workspaces["user-a"], "Alice's roadmap: ship the runtime docs.")
+        seed_workspace(workspaces["user-b"], "Bob's reminder: rotate the API tokens.")
+
+        async with MCPRuntime(
+            max_connections=10,
+            max_in_flight_calls=8,
+            observer=observer,
+        ) as runtime:
+            for request_number in (1, 2):
+                answers = await asyncio.gather(
+                    *(serve_user(runtime, user_id, path) for user_id, path in workspaces.items())
+                )
+                for user_id, answer in zip(workspaces, answers, strict=True):
+                    print(f"\n[request {request_number}, {user_id}] {answer}")
+
+            # snapshot() is synchronous and thread-safe: poll it from a metrics
+            # scraper on an interval. Both request rounds have released their
+            # leases, while the two tenant connections remain warm.
+            snapshot = runtime.snapshot()
+            print(f"\nruntime state: {snapshot.state.value}")
+            for connection_snapshot in snapshot.connections:
+                print(
+                    f"  {connection_snapshot.tenant_key}/{connection_snapshot.connection_key}: "
+                    f"{connection_snapshot.status.value} "
+                    f"(leases={connection_snapshot.leases}, "
+                    f"active_calls={connection_snapshot.active_calls})"
+                )
+
+            # Four fresh Agents used only two physical MCP connections.
+            print(f"physical connections opened: {observer.counts['MCPConnectionOpening']}")
+
+        # The context manager drains leases and closes every transport once.
+        print(f"after close: {runtime.snapshot().state.value}")
+
+        print("\nlifecycle events observed:")
+        for event_name, count in sorted(observer.counts.items()):
+            print(f"  {event_name}: {count}")
+
+
+asyncio.run(main())

--- a/packages/python/src/dendrux/mcp/__init__.py
+++ b/packages/python/src/dendrux/mcp/__init__.py
@@ -1,20 +1,26 @@
 """MCP (Model Context Protocol) integration for Dendrux.
 
-Provides a production client wrapper over the official MCP Python SDK.
+The managed runtime is the production entry point: one process-wide
+:class:`MCPRuntime` shares physical connections across Agents, enforces
+capacity, breaks circuits, and reports operational telemetry.
 
 Usage:
-    from dendrux.mcp import MCPHost, MCPSource
+    from dendrux.mcp import MCPRuntime, MCPSource
 
-    host = MCPHost([
-        MCPSource.stdio("filesystem", command=[
-            "npx", "-y", "@modelcontextprotocol/server-filesystem", "/tmp",
-        ]),
-    ])
+    runtime = MCPRuntime()
+    connection = runtime.bind(
+        connection_key="github-1",
+        source=MCPSource.http("github", "https://mcp.example.com"),
+    )
 
     agent = Agent(
         provider=provider,
-        tool_sources=[host],
+        tool_sources=[connection.tools()],
     )
+
+:class:`MCPHost` remains the simpler application-owned facade for sharing a
+fixed set of connections across Agents. :class:`MCPServer` is the directly
+Agent-owned, single-connection facade.
 
 Requires the ``mcp`` package: ``pip install dendrux[mcp]``
 """
@@ -29,22 +35,120 @@ except ModuleNotFoundError as err:
     raise  # Real import error from within the mcp package
 
 from dendrux.mcp._errors import (  # noqa: E402
+    MCPAuthenticationError,
+    MCPBindingConflictError,
+    MCPCallCapacityError,
+    MCPCapacityError,
+    MCPCircuitOpenError,
+    MCPConnectionCapacityError,
     MCPConnectionError,
+    MCPConnectionEvictingError,
+    MCPConnectionLostError,
+    MCPConnectionStateError,
+    MCPCredentialError,
     MCPError,
+    MCPOutcomeUnknownError,
     MCPResultTooLargeError,
+    MCPRuntimeClosedError,
+    MCPStaleConnectionError,
     MCPToolCallError,
 )
 from dendrux.mcp._host import MCPHost  # noqa: E402
+from dendrux.mcp._observability import (  # noqa: E402
+    MCPCallCapacityRejected,
+    MCPCircuitClosed,
+    MCPCircuitOpened,
+    MCPCircuitProbing,
+    MCPConnectionAborted,
+    MCPConnectionCapacityRejected,
+    MCPConnectionClosed,
+    MCPConnectionEvent,
+    MCPConnectionFailed,
+    MCPConnectionOpened,
+    MCPConnectionOpening,
+    MCPConnectionSnapshot,
+    MCPConnectionStatus,
+    MCPEvictionCompleted,
+    MCPEvictionStarted,
+    MCPOpenCircuitSnapshot,
+    MCPPhysicalConnectionEvent,
+    MCPRuntimeEvent,
+    MCPRuntimeObserver,
+    MCPRuntimeShutdownCompleted,
+    MCPRuntimeShutdownStarted,
+    MCPRuntimeSnapshot,
+    MCPRuntimeState,
+    MCPToolCallCancelled,
+    MCPToolCallCompleted,
+    MCPToolCallFailed,
+    MCPToolCallOutcomeUnknown,
+    MCPToolCallStarted,
+)
+from dendrux.mcp._runtime import (  # noqa: E402
+    MCPConnection,
+    MCPCredentialProvider,
+    MCPEvictionMode,
+    MCPRuntime,
+    MCPToolPolicy,
+    MCPToolView,
+)
 from dendrux.mcp._server import MCPServer  # noqa: E402
 from dendrux.mcp._source import MCPFailureMode, MCPSource  # noqa: E402
 
 __all__ = [
+    "MCPAuthenticationError",
+    "MCPBindingConflictError",
+    "MCPCallCapacityError",
+    "MCPCallCapacityRejected",
+    "MCPCapacityError",
+    "MCPCircuitClosed",
+    "MCPCircuitOpenError",
+    "MCPCircuitOpened",
+    "MCPCircuitProbing",
+    "MCPConnection",
+    "MCPConnectionAborted",
+    "MCPConnectionCapacityError",
+    "MCPConnectionCapacityRejected",
+    "MCPConnectionClosed",
     "MCPConnectionError",
+    "MCPConnectionEvent",
+    "MCPConnectionEvictingError",
+    "MCPConnectionFailed",
+    "MCPConnectionLostError",
+    "MCPConnectionOpened",
+    "MCPConnectionOpening",
+    "MCPConnectionSnapshot",
+    "MCPConnectionStateError",
+    "MCPConnectionStatus",
+    "MCPCredentialError",
+    "MCPCredentialProvider",
     "MCPError",
+    "MCPEvictionCompleted",
+    "MCPEvictionMode",
+    "MCPEvictionStarted",
     "MCPFailureMode",
     "MCPHost",
+    "MCPOpenCircuitSnapshot",
+    "MCPOutcomeUnknownError",
+    "MCPPhysicalConnectionEvent",
     "MCPResultTooLargeError",
+    "MCPRuntime",
+    "MCPRuntimeClosedError",
+    "MCPRuntimeEvent",
+    "MCPRuntimeObserver",
+    "MCPRuntimeShutdownCompleted",
+    "MCPRuntimeShutdownStarted",
+    "MCPRuntimeSnapshot",
+    "MCPRuntimeState",
     "MCPServer",
     "MCPSource",
+    "MCPStaleConnectionError",
+    "MCPToolCallCancelled",
+    "MCPToolCallCompleted",
     "MCPToolCallError",
+    "MCPToolCallFailed",
+    "MCPToolCallOutcomeUnknown",
+    "MCPToolCallStarted",
+    "MCPToolPolicy",
+    "MCPToolView",
 ]

--- a/packages/python/src/dendrux/mcp/_client.py
+++ b/packages/python/src/dendrux/mcp/_client.py
@@ -106,6 +106,10 @@ class MCPClientAdapter:
 
     def __init__(self, source: MCPSource) -> None:
         self.source = source
+        self._close_requested = asyncio.Event()
+        self._connect_error: BaseException | None = None
+        self._owner_task: asyncio.Task[None] | None = None
+        self._ready = asyncio.Event()
         self._stack: AsyncExitStack | None = None
         self._client: Client | None = None
         self.info: MCPConnectionInfo | None = None
@@ -115,8 +119,42 @@ class MCPClientAdapter:
         return self._client is not None
 
     async def connect(self) -> None:
-        if self._client is not None:
+        if self._owner_task is not None:
             raise RuntimeError(f"MCP source '{self.source.name}' is already connected.")
+
+        self._owner_task = asyncio.create_task(
+            self._run_lifecycle(),
+            name=f"dendrux-mcp-{self.source.name}",
+        )
+        try:
+            await asyncio.shield(self._ready.wait())
+        except asyncio.CancelledError:
+            self._close_requested.set()
+            self._owner_task.cancel()
+            await asyncio.gather(self._owner_task, return_exceptions=True)
+            raise
+        if self._connect_error is not None:
+            raise self._connect_error from None
+
+    async def _run_lifecycle(self) -> None:
+        """Enter and exit SDK contexts in this one owning task."""
+        try:
+            failure = await self._open()
+        except BaseException as exc:
+            failure = self._safe_error("connect to", exc) if isinstance(exc, Exception) else exc
+        if failure is not None:
+            self._connect_error = failure
+            self._ready.set()
+            return
+
+        self._ready.set()
+        try:
+            await self._close_requested.wait()
+        finally:
+            await self._close_owned_stack()
+
+    async def _open(self) -> BaseException | None:
+        """Open the transport, returning a detached safe failure if needed."""
 
         stack = AsyncExitStack()
         await stack.__aenter__()
@@ -164,7 +202,7 @@ class MCPClientAdapter:
         except BaseException as exc:
             failure: BaseException = exc
         else:
-            return
+            return None
         cleanup_failure: BaseException | None = None
         try:
             await stack.aclose()
@@ -175,9 +213,9 @@ class MCPClientAdapter:
         # wins; ordinary cleanup errors are retained only as redacted debug
         # diagnostics.
         if isinstance(failure, asyncio.CancelledError):
-            raise failure from None
+            return failure
         if cleanup_failure is not None and not isinstance(cleanup_failure, Exception):
-            raise cleanup_failure from None
+            return cleanup_failure
         if cleanup_failure is not None:
             logger.debug(
                 "MCP source '%s' cleanup after connect failure also failed: %s (%s)",
@@ -189,7 +227,7 @@ class MCPClientAdapter:
         # original exception as __context__ even with `from None`, and
         # error-monitoring SDKs walk __context__ regardless of
         # __suppress_context__ — which would republish the endpoint.
-        raise self._safe_error("connect to", failure) from None
+        return self._safe_error("connect to", failure)
 
     async def list_tools(self) -> list[Any]:
         client = self._require_client()
@@ -257,6 +295,18 @@ class MCPClientAdapter:
         )
 
     async def close(self) -> None:
+        owner_task = self._owner_task
+        if owner_task is None:
+            self._client = None
+            self.info = None
+            return
+        self._close_requested.set()
+        if not self._ready.is_set():
+            owner_task.cancel()
+        await asyncio.shield(owner_task)
+
+    async def _close_owned_stack(self) -> None:
+        """Close the SDK stack from the same task that entered it."""
         stack = self._stack
         self._stack = None
         self._client = None

--- a/packages/python/src/dendrux/mcp/_client.py
+++ b/packages/python/src/dendrux/mcp/_client.py
@@ -8,27 +8,46 @@ from contextlib import AsyncExitStack
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+import anyio
 import httpx2
 from mcp import Client, StdioServerParameters
 from mcp.client.stdio import stdio_client
 from mcp.client.streamable_http import streamable_http_client
+from mcp.shared.exceptions import MCPError as SDKMCPError
+from mcp.types import CONNECTION_CLOSED
 
 from dendrux.mcp._errors import MCPAuthenticationError, MCPConnectionError
 from dendrux.mcp._source import safe_source_exception_detail, source_has_opaque_credentials
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from dendrux.mcp._source import MCPSource
 
 logger = logging.getLogger(__name__)
 
 _AUTH_REJECTION_STATUSES = (401, 403)
 
+# Failures that mean the transport or session itself died. Timeouts are
+# deliberately absent (a slow server is not a dead one), as are HTTP status
+# errors (a rejection arrives over a working connection) and local protocol
+# errors (a client-side bug does not invalidate the transport).
+_CONNECTION_LOSS_TYPES: tuple[type[BaseException], ...] = (
+    ConnectionError,
+    EOFError,
+    httpx2.NetworkError,
+    httpx2.RemoteProtocolError,
+    anyio.BrokenResourceError,
+    anyio.ClosedResourceError,
+    anyio.EndOfStream,
+)
 
-def _authentication_status(exc: BaseException) -> int | None:
-    """Find a credential-rejection HTTP status anywhere in an error tree.
 
-    SDK and transport layers wrap the original ``httpx`` status error, so the
-    cause/context chain and exception-group branches are all searched.
+def _iter_error_tree(exc: BaseException) -> Iterator[BaseException]:
+    """Yield every distinct exception reachable from one failure.
+
+    SDK and transport layers wrap the original error, so the cause/context
+    chains and exception-group branches are all walked.
     """
     stack: list[BaseException] = [exc]
     seen: set[int] = set()
@@ -37,19 +56,39 @@ def _authentication_status(exc: BaseException) -> int | None:
         if id(node) in seen:
             continue
         seen.add(id(node))
-        response = getattr(node, "response", None)
-        status = getattr(response, "status_code", None)
-        if status is None:
-            status = getattr(node, "status_code", None)
-        if status in _AUTH_REJECTION_STATUSES:
-            return int(status)
+        yield node
         if isinstance(node, BaseExceptionGroup):
             stack.extend(node.exceptions)
         if node.__cause__ is not None:
             stack.append(node.__cause__)
         if node.__context__ is not None:
             stack.append(node.__context__)
+
+
+def _authentication_status(exc: BaseException) -> int | None:
+    """Find a credential-rejection HTTP status anywhere in an error tree."""
+    for node in _iter_error_tree(exc):
+        response = getattr(node, "response", None)
+        status = getattr(response, "status_code", None)
+        if status is None:
+            status = getattr(node, "status_code", None)
+        if status in _AUTH_REJECTION_STATUSES:
+            return int(status)
     return None
+
+
+def is_connection_loss(exc: BaseException) -> bool:
+    """Whether an error tree shows the physical transport or session died.
+
+    Used by the managed runtime to distinguish a dead connection — which
+    must be fenced and replaced — from a tool that merely failed over a
+    working one, which must never poison the shared connection.
+    """
+    return any(
+        isinstance(node, _CONNECTION_LOSS_TYPES)
+        or (isinstance(node, SDKMCPError) and node.code == CONNECTION_CLOSED)
+        for node in _iter_error_tree(exc)
+    )
 
 
 @dataclass(frozen=True, slots=True)

--- a/packages/python/src/dendrux/mcp/_errors.py
+++ b/packages/python/src/dendrux/mcp/_errors.py
@@ -134,6 +134,17 @@ class MCPStaleConnectionError(MCPConnectionStateError):
     """
 
 
+class MCPConnectionLostError(MCPConnectionStateError):
+    """The physical transport behind a managed connection died.
+
+    Raised only for calls that were *never sent*: they were queued for, or
+    routed to, an entry another call had already proven broken. Nothing
+    reached the server, so acquiring tools again — which opens a replacement
+    connection with freshly resolved credentials — and retrying is safe.
+    The identity stays registered; only the physical transport is gone.
+    """
+
+
 class MCPCallCapacityError(MCPCapacityError):
     """No MCP tool-call slot became free within the wait budget.
 
@@ -163,13 +174,23 @@ class MCPCallCapacityError(MCPCapacityError):
 
 
 class MCPToolCallError(MCPError):
-    """An MCP server returned an unsuccessful tool result."""
+    """An MCP server returned an unsuccessful tool result.
+
+    ``connection_lost`` is True when the failure tree shows the transport or
+    session died mid-call, rather than the tool merely failing over a working
+    connection. The managed runtime consults it to fence the shared physical
+    connection; the message itself is identical either way.
+    """
+
+    connection_lost: bool = False
 
 
 class MCPOutcomeUnknownError(MCPError):
-    """A tool call was interrupted by forced eviction with an unknown outcome.
+    """A tool call was interrupted with an unknown outcome.
 
-    The server may already have applied the effect, so the call must never be
+    Raised when a forced eviction or shutdown tears the transport out from
+    under a running call, and when the transport itself dies mid-call. The
+    server may already have applied the effect, so the call must never be
     retried automatically. It is deliberately not an :class:`MCPToolCallError`
     subclass: handlers that retry failed tool calls must not catch this.
     """

--- a/packages/python/src/dendrux/mcp/_errors.py
+++ b/packages/python/src/dendrux/mcp/_errors.py
@@ -145,6 +145,40 @@ class MCPConnectionLostError(MCPConnectionStateError):
     """
 
 
+class MCPCircuitOpenError(MCPConnectionStateError):
+    """The connection's circuit breaker is open after repeated failures.
+
+    Raised before anything is sent: new physical connections for this
+    identity are rejected until the cooldown elapses, so an unavailable
+    server is not hammered by a reconnect storm. ``retry_after`` is the
+    remaining cooldown in seconds and is safe to surface to end users.
+    After the cooldown one probe connection is attempted and concurrent
+    callers share its outcome. Evicting the identity, or rebinding it with
+    changed source configuration or ``credential_identity``, resets the
+    circuit immediately.
+    """
+
+    def __init__(
+        self,
+        identity: tuple[str | None, str],
+        *,
+        retry_after: float,
+        failure_count: int,
+        last_failure: str | None,
+    ) -> None:
+        self.retry_after = retry_after
+        self.failure_count = failure_count
+        self.last_failure = last_failure
+        detail = f" (last failure: {last_failure})" if last_failure else ""
+        super().__init__(
+            identity,
+            f"MCP connection {identity!r} circuit is open after {failure_count} "
+            f"consecutive connection failures{detail}. New connections are "
+            f"rejected for another {retry_after:.1f}s; evict, or rebind with changed "
+            "source configuration or credential_identity, to reset immediately.",
+        )
+
+
 class MCPCallCapacityError(MCPCapacityError):
     """No MCP tool-call slot became free within the wait budget.
 

--- a/packages/python/src/dendrux/mcp/_host.py
+++ b/packages/python/src/dendrux/mcp/_host.py
@@ -3,14 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable, Sequence  # noqa: TC003
 from typing import TYPE_CHECKING, Any
 
 from dendrux.mcp._server import MCPServer
 from dendrux.mcp._source import MCPSource
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
-
     from dendrux.types import ToolDef
 
 

--- a/packages/python/src/dendrux/mcp/_observability.py
+++ b/packages/python/src/dendrux/mcp/_observability.py
@@ -1,0 +1,346 @@
+"""Immutable operational telemetry types for the managed MCP runtime.
+
+The runtime-level equivalent of connection-pool metrics: point-in-time
+snapshots (:meth:`MCPRuntime.snapshot`) and typed lifecycle events
+(``MCPRuntime(observer=...)``). Everything here is process-local and
+storage-free — no database, no exporter, no hosted monitoring. Developers
+bridge these signals to Prometheus, OpenTelemetry, Datadog, logs, or
+their own systems.
+
+Every field is value-free by construction: identities, validated source
+names, class names, counts, and durations. Credentials, URLs, tool
+arguments, results, and error text never appear. Tenant and connection
+keys are carried on the typed objects for the application to use, but the
+runtime itself never writes them to its own logs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Literal, Protocol, runtime_checkable
+
+
+class MCPRuntimeState(StrEnum):
+    """Application-owned managed runtime lifecycle state.
+
+    Defined here, in the dependency-free types module, so every public
+    snapshot annotation resolves at runtime for reflection-based tooling.
+    """
+
+    OPEN = "open"
+    DRAINING = "draining"
+    CLOSED = "closed"
+
+
+class MCPConnectionStatus(StrEnum):
+    """Point-in-time state of one physical managed connection."""
+
+    CONNECTING = "connecting"
+    ACTIVE = "active"
+    IDLE = "idle"
+    BROKEN = "broken"
+    CLOSING = "closing"
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class MCPConnectionSnapshot:
+    """One physical connection as it existed at snapshot time.
+
+    ``instance_id`` is the runtime-wide monotonic id of this exact physical
+    connection; a reconnect under the same identity gets a new one.
+    """
+
+    tenant_key: str | None
+    connection_key: str
+    source_name: str
+    instance_id: int
+    status: MCPConnectionStatus
+    leases: int
+    active_calls: int
+
+    @property
+    def identity(self) -> tuple[str | None, str]:
+        """Return the registry identity of this connection."""
+        return self.tenant_key, self.connection_key
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class MCPOpenCircuitSnapshot:
+    """One registered identity whose circuit breaker is currently open.
+
+    ``retry_after`` is the remaining cooldown in seconds; ``0.0`` means the
+    cooldown has elapsed and the next acquisition becomes the probe.
+    """
+
+    tenant_key: str | None
+    connection_key: str
+    source_name: str
+    failure_count: int
+    last_failure: str | None
+    retry_after: float
+
+    @property
+    def identity(self) -> tuple[str | None, str]:
+        """Return the registry identity of this circuit."""
+        return self.tenant_key, self.connection_key
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class MCPRuntimeSnapshot:
+    """Immutable point-in-time view of runtime operational health.
+
+    Taken atomically under one lock acquisition, so the numbers are
+    mutually consistent: every admitted call belongs to a listed
+    connection, and waiters count callers queued at snapshot time.
+
+    ``in_flight_calls`` counts admitted calls occupying call capacity.
+    A forcibly interrupted call whose transport ignores cancellation has
+    its capacity reclaimed and moves to ``detached_calls`` until its
+    operation actually exits, so reclaimed-but-running work stays visible.
+    """
+
+    state: MCPRuntimeState
+    connections: tuple[MCPConnectionSnapshot, ...]
+    in_flight_calls: int
+    detached_calls: int
+    connection_waiters: int
+    call_waiters: int
+    open_circuits: tuple[MCPOpenCircuitSnapshot, ...]
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class MCPRuntimeEvent:
+    """Base class for managed-runtime lifecycle events."""
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class MCPConnectionEvent(MCPRuntimeEvent):
+    """Base class for events scoped to one connection identity."""
+
+    tenant_key: str | None
+    connection_key: str
+    source_name: str
+
+    @property
+    def identity(self) -> tuple[str | None, str]:
+        """Return the registry identity this event belongs to."""
+        return self.tenant_key, self.connection_key
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class MCPPhysicalConnectionEvent(MCPConnectionEvent):
+    """Base class for events tied to one exact physical connection.
+
+    ``instance_id`` is a runtime-wide monotonic id assigned when the
+    physical connection is created. It distinguishes overlapping lifetimes
+    under one identity — a resistant old transport still closing while a
+    replacement (possibly after a rebind) is already open and serving.
+    """
+
+    instance_id: int
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class MCPConnectionOpening(MCPPhysicalConnectionEvent):
+    """A physical connection attempt (connect + discovery) started.
+
+    Ends in exactly one of :class:`MCPConnectionOpened`,
+    :class:`MCPConnectionFailed`, or :class:`MCPConnectionAborted`.
+    """
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class MCPConnectionOpened(MCPPhysicalConnectionEvent):
+    """A physical connection established and discovered its tools."""
+
+    tool_count: int
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class MCPConnectionFailed(MCPPhysicalConnectionEvent):
+    """A physical connection attempt failed before becoming usable.
+
+    ``cause`` is the failure's class name only; transport error text is
+    never carried.
+    """
+
+    cause: str
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class MCPConnectionAborted(MCPPhysicalConnectionEvent):
+    """A connection attempt was abandoned without a server verdict.
+
+    Emitted when establishment is cancelled by shutdown, eviction, or
+    retirement, or completes only after losing its slot. Not a server
+    failure: it never counts toward the circuit breaker.
+    """
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class MCPConnectionClosed(MCPPhysicalConnectionEvent):
+    """The runtime released one physical connection and attempted close.
+
+    ``clean`` is False when close raised or did not finish within the bounded
+    cleanup grace. Ownership is released either way, and cleanup detail goes
+    only to value-free logs. Emitted exactly once per opened connection.
+    """
+
+    reason: Literal["idle", "broken", "evicted", "shutdown"]
+    clean: bool
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class MCPEvictionStarted(MCPConnectionEvent):
+    """An explicit eviction began for a live connection."""
+
+    mode: Literal["drain", "force"]
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class MCPEvictionCompleted(MCPConnectionEvent):
+    """An explicit eviction finished; the identity is bindable again.
+
+    ``forced`` is True when running work was interrupted — either
+    ``mode="force"`` or a drain that timed out and escalated.
+    """
+
+    forced: bool
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class MCPCircuitOpened(MCPConnectionEvent):
+    """Consecutive failures reached the threshold; acquisitions fail fast.
+
+    Also emitted when a failed probe re-arms an already-open circuit.
+    """
+
+    failure_count: int
+    last_failure: str | None
+    reset_timeout: float
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class MCPCircuitProbing(MCPConnectionEvent):
+    """The cooldown elapsed and one half-open probe connection started."""
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class MCPCircuitClosed(MCPConnectionEvent):
+    """A previously open circuit closed after a successful connection."""
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class MCPConnectionCapacityRejected(MCPConnectionEvent):
+    """An acquisition was rejected: no connection slot within its budget."""
+
+    limit: int
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class MCPCallCapacityRejected(MCPConnectionEvent):
+    """A tool call was shed: no call slot became free within its budget."""
+
+    tool: str
+    limit: int
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class MCPToolCallStarted(MCPPhysicalConnectionEvent):
+    """A tool call was admitted and handed to the transport.
+
+    ``tool`` is the Agent-visible canonical name. Every started call ends
+    in exactly one of :class:`MCPToolCallCompleted`,
+    :class:`MCPToolCallFailed`, :class:`MCPToolCallOutcomeUnknown`, or
+    :class:`MCPToolCallCancelled`.
+    """
+
+    tool: str
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class MCPToolCallCompleted(MCPPhysicalConnectionEvent):
+    """A tool call returned a definitive server response."""
+
+    tool: str
+    duration: float
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class MCPToolCallFailed(MCPPhysicalConnectionEvent):
+    """A tool call failed over a functioning connection.
+
+    ``cause`` is the failure's class name only.
+    """
+
+    tool: str
+    duration: float
+    cause: str
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class MCPToolCallOutcomeUnknown(MCPPhysicalConnectionEvent):
+    """A tool call was interrupted with an unknown outcome.
+
+    The server may already have applied the call; it is never retried
+    automatically. A cancellation-resistant operation is terminalized here
+    when the runtime reclaims its capacity; its caller may still observe the
+    transport eventually exit, but no second telemetry terminal is emitted.
+    """
+
+    tool: str
+    duration: float
+    reason: Literal["forced", "connection_lost"]
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class MCPToolCallCancelled(MCPPhysicalConnectionEvent):
+    """The caller abandoned a tool call before a server response.
+
+    Emitted when the application cancels the calling task — or
+    process-level control flow unwinds it — while the call is in flight.
+    The runtime did not interrupt it and no server verdict was observed.
+    """
+
+    tool: str
+    duration: float
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class MCPRuntimeShutdownStarted(MCPRuntimeEvent):
+    """Runtime shutdown began draining leases and calls."""
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class MCPRuntimeShutdownCompleted(MCPRuntimeEvent):
+    """Runtime shutdown finished; the runtime is permanently closed.
+
+    ``forced`` is True when the drain timed out and running work was
+    interrupted. It is the final event emitted by this runtime, including
+    when resistant transport cleanup continues without runtime ownership.
+    """
+
+    forced: bool
+
+
+@runtime_checkable
+class MCPRuntimeObserver(Protocol):
+    """Application callback receiving managed-runtime lifecycle events.
+
+    ``on_event`` must be a plain synchronous callable — coroutine
+    functions and async callable objects are rejected at construction;
+    awaitables returned through a synchronous wrapper are disposed and the
+    event is dropped. It is invoked on the
+    runtime's event loop, always outside runtime locks, so it may safely
+    call :meth:`MCPRuntime.snapshot`. It must be fast and non-blocking —
+    hand events to a metrics client or queue of the application's choosing
+    rather than doing I/O inline. Exceptions it raises are swallowed and
+    logged without detail: telemetry never breaks MCP work, but a failing
+    observer silently drops its own events. Every ``BaseException`` is
+    isolated, including cancellation and process-level control flow.
+    """
+
+    def on_event(self, event: MCPRuntimeEvent) -> None:
+        """Handle one immutable lifecycle event."""
+        ...

--- a/packages/python/src/dendrux/mcp/_runtime.py
+++ b/packages/python/src/dendrux/mcp/_runtime.py
@@ -18,6 +18,7 @@ from dendrux.mcp._client import MCPClientAdapter
 from dendrux.mcp._errors import (
     MCPBindingConflictError,
     MCPCallCapacityError,
+    MCPCircuitOpenError,
     MCPConnectionCapacityError,
     MCPConnectionError,
     MCPConnectionEvictingError,
@@ -462,6 +463,14 @@ class _ViewToolSource(MCPServer):
                         reporting_permit=permit,
                     )
                     raise unknown_outcome("connection_lost") from exc
+                if isinstance(exc, Exception):
+                    # Any ordinary tool failure arrived over a functioning
+                    # MCP session. Process-level control flow is not a server
+                    # response and must not change health state.
+                    connection.runtime._record_healthy_tool_response(
+                        connection.identity,
+                        entry,
+                    )
                 raise
             else:
                 interruption = permit.interruption
@@ -473,6 +482,10 @@ class _ViewToolSource(MCPServer):
                     # A normal return is a definitive server response. Forced
                     # teardown prevents future work; it does not make this
                     # already-completed call's outcome uncertain.
+                connection.runtime._record_healthy_tool_response(
+                    connection.identity,
+                    entry,
+                )
                 return result
             finally:
                 connection.runtime._end_call(connection.identity, permit)
@@ -511,6 +524,7 @@ class _ConnectionEntry:
         "adapter",
         "broken",
         "call_permits",
+        "circuit",
         "close_started",
         "fenced",
         "force_evicted",
@@ -542,6 +556,10 @@ class _ConnectionEntry:
         self.force_evicted = False
         self.broken = False
         self.close_started = False
+        # The circuit of the registration this entry was opened under. Held
+        # directly so a failure recorded by a slow attempt lands on the
+        # circuit that admitted it, never on one a later rebind reset.
+        self.circuit: _CircuitState | None = None
         # Idle retirement: a pending timer, then the task closing this exact
         # physical entry. Both are scoped to this entry so a stale callback can
         # never touch a replacement connection.
@@ -597,6 +615,31 @@ class _Admission:
         self.waiters = 0
 
 
+class _CircuitState:
+    """Consecutive connection-failure record for one registered identity.
+
+    Owned by the registration, not the physical entry, so it survives the
+    failed entries it is counting. Eviction deletes the registration — and
+    the circuit with it — while a rebind with changed configuration or
+    credential identity replaces it with a fresh one. ``open_until`` is an
+    event-loop timestamp; while it lies in the future, new physical
+    connections for the identity are rejected.
+    """
+
+    __slots__ = (
+        "consecutive_failures",
+        "connection_loss_failures",
+        "last_failure",
+        "open_until",
+    )
+
+    def __init__(self) -> None:
+        self.consecutive_failures = 0
+        self.connection_loss_failures = 0
+        self.last_failure: str | None = None
+        self.open_until: float | None = None
+
+
 @dataclass(slots=True)
 class _Registration:
     """Canonical configuration for one connection identity.
@@ -609,6 +652,7 @@ class _Registration:
     generation: int
     credentials: MCPCredentialProvider | None
     credential_identity: str | None
+    circuit: _CircuitState = field(default_factory=_CircuitState)
 
 
 def _same_connection_config(registered: MCPSource, candidate: MCPSource) -> bool:
@@ -654,6 +698,19 @@ class MCPRuntime:
     is handed to background tracking rather than waited on, so no caller can
     be blocked by a misbehaving server.
 
+    Repeated connection failures open a per-identity **circuit breaker**:
+    once ``circuit_failure_threshold`` failures accumulate — connection
+    attempts and mid-call transport losses alike — new acquisitions fail fast
+    with :class:`MCPCircuitOpenError`, whose ``retry_after`` can be surfaced
+    to users, instead of hammering an unavailable server. After
+    ``circuit_reset_timeout`` seconds the next acquisition becomes a single
+    probe that concurrent callers wait behind. A successful handshake clears
+    connection-attempt failures; mid-call losses remain until a confirmed
+    tool response proves the replacement session healthy. Eviction, or
+    rebinding with changed configuration or ``credential_identity``, resets
+    the circuit explicitly. The breaker gates only new physical connections:
+    live connections, their tool calls, and other identities are unaffected.
+
     Tool calls are bounded separately by ``max_in_flight_calls``, one budget
     shared by every connection: any number of Agents may hold leases, but only
     that many MCP operations are admitted at once. Calls over the limit queue
@@ -671,6 +728,8 @@ class MCPRuntime:
         connection_wait_timeout: float = 10.0,
         call_wait_timeout: float = 10.0,
         shutdown_timeout: float = 30.0,
+        circuit_failure_threshold: int | None = 5,
+        circuit_reset_timeout: float = 30.0,
     ) -> None:
         self.max_connections = _positive_int(max_connections, "max_connections")
         self.max_in_flight_calls = _positive_int(
@@ -693,6 +752,15 @@ class MCPRuntime:
         # itself. 0 sheds load immediately instead of queueing.
         self.call_wait_timeout = _non_negative_float(call_wait_timeout, "call_wait_timeout")
         self.shutdown_timeout = _positive_float(shutdown_timeout, "shutdown_timeout")
+        # Circuit breaker: after this many consecutive connection failures on
+        # one identity, new physical connections are rejected for the reset
+        # timeout, then one probe is admitted. None disables the breaker.
+        self.circuit_failure_threshold: int | None = (
+            None
+            if circuit_failure_threshold is None
+            else _positive_int(circuit_failure_threshold, "circuit_failure_threshold")
+        )
+        self.circuit_reset_timeout = _positive_float(circuit_reset_timeout, "circuit_reset_timeout")
         self._state = MCPRuntimeState.OPEN
         # The registered source is the canonical configuration for an
         # identity. evict() must remove entries here, or an evicted
@@ -1076,6 +1144,113 @@ class MCPRuntime:
                 type(exc).__name__,
             )
 
+    def _circuit_retry_after(self, circuit: _CircuitState, now: float) -> float | None:
+        """Remaining cooldown before this identity may open a connection.
+
+        ``None`` admits the caller: the circuit is closed, or its cooldown
+        has elapsed and this acquisition becomes the probe — single-flight
+        entry creation is what guarantees exactly one physical attempt,
+        however many callers arrive with it. Caller must hold the runtime
+        lock.
+        """
+        if circuit.open_until is None or now >= circuit.open_until:
+            return None
+        return circuit.open_until - now
+
+    def _entry_owns_current_circuit(
+        self,
+        identity: tuple[str | None, str],
+        entry: _ConnectionEntry,
+    ) -> bool:
+        """Whether this live entry may mutate its registration's circuit.
+
+        Cancellation-resistant establishment tasks can finish after their
+        entry was retired and a replacement has already changed the circuit.
+        Entry identity and circuit-object identity together prevent those
+        obsolete outcomes from overwriting the current verdict. Caller must
+        hold the runtime lock.
+        """
+        registration = self._registrations.get(identity)
+        return (
+            self._entries.get(identity) is entry
+            and not entry.fenced
+            and registration is not None
+            and registration.circuit is entry.circuit
+        )
+
+    def _record_circuit_failure(
+        self,
+        identity: tuple[str | None, str],
+        entry: _ConnectionEntry,
+        cause: str,
+        *,
+        connection_lost: bool = False,
+    ) -> None:
+        """Count one connection failure toward the entry's circuit.
+
+        ``cause`` must be value-free (an exception class name or a fixed
+        phrase): it is rendered into rejection messages and logs. Caller
+        must hold the runtime lock.
+        """
+        circuit = entry.circuit
+        threshold = self.circuit_failure_threshold
+        if (
+            circuit is None
+            or threshold is None
+            or not self._entry_owns_current_circuit(identity, entry)
+        ):
+            return
+        circuit.consecutive_failures += 1
+        if connection_lost:
+            circuit.connection_loss_failures += 1
+        circuit.last_failure = cause
+        if circuit.consecutive_failures < threshold or self._loop is None:
+            return
+        circuit.open_until = self._loop.time() + self.circuit_reset_timeout
+        logger.warning(
+            "MCP source '%s' circuit opened after %d consecutive connection "
+            "failures (last: %s); rejecting new connections for %.1fs.",
+            entry.source.name,
+            circuit.consecutive_failures,
+            cause,
+            self.circuit_reset_timeout,
+        )
+
+    def _record_circuit_connection_success(
+        self,
+        identity: tuple[str | None, str],
+        entry: _ConnectionEntry,
+    ) -> None:
+        """Record a successful handshake without hiding unstable sessions.
+
+        Establishment clears connection-attempt failures. Mid-call losses
+        survive until a real tool response proves the replacement session is
+        healthy; otherwise a server that accepts discovery but drops every
+        call could reconnect forever without opening its circuit. Caller must
+        hold the runtime lock.
+        """
+        circuit = entry.circuit
+        if circuit is None or not self._entry_owns_current_circuit(identity, entry):
+            return
+        circuit.consecutive_failures = circuit.connection_loss_failures
+        circuit.last_failure = "connection loss" if circuit.connection_loss_failures else None
+        circuit.open_until = None
+
+    def _record_healthy_tool_response(
+        self,
+        identity: tuple[str | None, str],
+        entry: _ConnectionEntry,
+    ) -> None:
+        """Reset the circuit after a confirmed response on the live entry."""
+        with self._lock:
+            circuit = entry.circuit
+            if circuit is None or not self._entry_owns_current_circuit(identity, entry):
+                return
+            circuit.consecutive_failures = 0
+            circuit.connection_loss_failures = 0
+            circuit.last_failure = None
+            circuit.open_until = None
+
     def _connection_lost(
         self,
         identity: tuple[str | None, str],
@@ -1099,6 +1274,12 @@ class MCPRuntime:
             if not entry.fenced:
                 if self._state is not MCPRuntimeState.OPEN or self._loop is None:
                     return  # shutdown already tears every transport down
+                self._record_circuit_failure(
+                    identity,
+                    entry,
+                    "connection loss",
+                    connection_lost=True,
+                )
                 entry.broken = True
                 entry.fenced = True
                 self._cancel_idle(entry)
@@ -1203,8 +1384,20 @@ class MCPRuntime:
                             entry.leases += 1
                             task = entry.task
                             break
+                        # Only opening a NEW physical connection consults the
+                        # circuit; a live entry above is reused regardless.
+                        retry_after = self._circuit_retry_after(registration.circuit, loop.time())
+                        if retry_after is not None:
+                            circuit = registration.circuit
+                            raise MCPCircuitOpenError(
+                                identity,
+                                retry_after=retry_after,
+                                failure_count=circuit.consecutive_failures,
+                                last_failure=circuit.last_failure,
+                            )
                         if self._can_admit(admission):
                             entry = _ConnectionEntry(registration.source)
+                            entry.circuit = registration.circuit
                             entry.task = loop.create_task(
                                 self._open_connection(
                                     identity,
@@ -1277,8 +1470,12 @@ class MCPRuntime:
             adapter = MCPClientAdapter(source)
             await adapter.connect()
             raw_tools = await adapter.list_tools()
-        except BaseException:
+        except BaseException as exc:
             with self._lock:
+                # A cancelled attempt is a verdict about this runtime's
+                # teardown, not about the server: only real failures count.
+                if isinstance(exc, Exception) and not isinstance(exc, asyncio.CancelledError):
+                    self._record_circuit_failure(identity, entry, type(exc).__name__)
                 if self._entries.get(identity) is entry and not entry.fenced:
                     # Discard so the identity can be retried with a fresh entry,
                     # freeing its slot and any idle timer a departed waiter armed.
@@ -1295,6 +1492,7 @@ class MCPRuntime:
                     )
             raise
         with self._lock:
+            self._record_circuit_connection_success(identity, entry)
             # A force-closed or evicted entry must never receive a live
             # adapter: a transport that suppressed cancellation could
             # otherwise publish into an already-closed runtime.
@@ -1701,6 +1899,12 @@ class MCPRuntime:
                 registration.source = source
                 registration.credentials = credentials
                 registration.credential_identity = credential_identity
+                if config_changed:
+                    # Rotated credentials or a changed endpoint deserve an
+                    # immediate attempt; the identical per-request rebind
+                    # above keeps its circuit, so a reconnect storm cannot
+                    # reset its own breaker.
+                    registration.circuit = _CircuitState()
 
             return MCPConnection(
                 runtime=self,

--- a/packages/python/src/dendrux/mcp/_runtime.py
+++ b/packages/python/src/dendrux/mcp/_runtime.py
@@ -9,7 +9,10 @@ import logging
 import math
 import re
 from collections import deque
-from collections.abc import Mapping
+
+# Public method annotations are resolved at runtime by documentation and
+# dependency-injection tooling.
+from collections.abc import Callable, Collection, Mapping  # noqa: TC003
 from dataclasses import dataclass, field, replace
 from threading import Lock
 from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
@@ -70,17 +73,16 @@ from dendrux.mcp._source import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Collection
-
     from dendrux.types import ToolDef
 
 logger = logging.getLogger(__name__)
 
 _NAMESPACE_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 
-# Post-drain grace for connection and cleanup tasks: enough for cooperative
-# cancellation/close to finish, but bounded when a transport misbehaves.
-_FORCED_CANCEL_GRACE = 0.05
+# Post-drain grace for connection and cleanup tasks: enough for the official
+# SDK to stop a stdio subprocess cleanly, but bounded when a transport
+# misbehaves.
+_FORCED_CANCEL_GRACE = 0.25
 
 
 MCPEvictionMode = Literal["drain", "force"]

--- a/packages/python/src/dendrux/mcp/_runtime.py
+++ b/packages/python/src/dendrux/mcp/_runtime.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import inspect
 import logging
 import math
 import re
 from collections import deque
 from collections.abc import Mapping
 from dataclasses import dataclass, field, replace
-from enum import StrEnum
 from threading import Lock
 from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
 
@@ -29,7 +29,40 @@ from dendrux.mcp._errors import (
     MCPStaleConnectionError,
     MCPToolCallError,
 )
-from dendrux.mcp._server import MCPServer, build_mcp_tool_defs, create_mcp_executor
+from dendrux.mcp._observability import (
+    MCPCallCapacityRejected,
+    MCPCircuitClosed,
+    MCPCircuitOpened,
+    MCPCircuitProbing,
+    MCPConnectionAborted,
+    MCPConnectionCapacityRejected,
+    MCPConnectionClosed,
+    MCPConnectionFailed,
+    MCPConnectionOpened,
+    MCPConnectionOpening,
+    MCPConnectionSnapshot,
+    MCPConnectionStatus,
+    MCPEvictionCompleted,
+    MCPEvictionStarted,
+    MCPOpenCircuitSnapshot,
+    MCPRuntimeEvent,
+    MCPRuntimeObserver,
+    MCPRuntimeShutdownCompleted,
+    MCPRuntimeShutdownStarted,
+    MCPRuntimeSnapshot,
+    MCPRuntimeState,
+    MCPToolCallCancelled,
+    MCPToolCallCompleted,
+    MCPToolCallFailed,
+    MCPToolCallOutcomeUnknown,
+    MCPToolCallStarted,
+)
+from dendrux.mcp._server import (
+    MCPServer,
+    _sanitize_tool_name,
+    build_mcp_tool_defs,
+    create_mcp_executor,
+)
 from dendrux.mcp._source import (
     MCPSource,
     safe_source_exception_detail,
@@ -52,14 +85,6 @@ _FORCED_CANCEL_GRACE = 0.05
 
 MCPEvictionMode = Literal["drain", "force"]
 _CallInterruption = Literal["forced", "connection_lost"]
-
-
-class MCPRuntimeState(StrEnum):
-    """Application-owned managed runtime lifecycle state."""
-
-    OPEN = "open"
-    DRAINING = "draining"
-    CLOSED = "closed"
 
 
 @runtime_checkable
@@ -392,7 +417,66 @@ class _ViewToolSource(MCPServer):
             max_result_bytes=self.source.max_result_bytes,
         )
         connection = self._view.connection
-        qualified_name = f"{self.name}__{mcp_tool_name}"
+        # The Agent-visible canonical name: same sanitization as discovery,
+        # so telemetry and error messages match what the model actually calls.
+        qualified_name = f"{self.name}__{_sanitize_tool_name(mcp_tool_name)}"
+        tenant_key, connection_key = connection.identity
+        # Physical telemetry is pinned to the source that opened the entry.
+        # A live rebind may change only the presentation name used as the next
+        # view's default namespace; it must not rename an existing socket.
+        source_name = entry.source.name
+        instance_id = entry.instance_id
+
+        def _started_event() -> MCPToolCallStarted:
+            return MCPToolCallStarted(
+                tenant_key=tenant_key,
+                connection_key=connection_key,
+                source_name=source_name,
+                instance_id=instance_id,
+                tool=qualified_name,
+            )
+
+        def _completed_event(duration: float) -> MCPToolCallCompleted:
+            return MCPToolCallCompleted(
+                tenant_key=tenant_key,
+                connection_key=connection_key,
+                source_name=source_name,
+                instance_id=instance_id,
+                tool=qualified_name,
+                duration=duration,
+            )
+
+        def _failed_event(duration: float, cause: str) -> MCPToolCallFailed:
+            return MCPToolCallFailed(
+                tenant_key=tenant_key,
+                connection_key=connection_key,
+                source_name=source_name,
+                instance_id=instance_id,
+                tool=qualified_name,
+                duration=duration,
+                cause=cause,
+            )
+
+        def _unknown_event(duration: float, reason: _CallInterruption) -> MCPToolCallOutcomeUnknown:
+            return MCPToolCallOutcomeUnknown(
+                tenant_key=tenant_key,
+                connection_key=connection_key,
+                source_name=source_name,
+                instance_id=instance_id,
+                tool=qualified_name,
+                duration=duration,
+                reason=reason,
+            )
+
+        def _cancelled_event(duration: float) -> MCPToolCallCancelled:
+            return MCPToolCallCancelled(
+                tenant_key=tenant_key,
+                connection_key=connection_key,
+                source_name=source_name,
+                instance_id=instance_id,
+                tool=qualified_name,
+                duration=duration,
+            )
 
         def unknown_outcome(reason: _CallInterruption) -> MCPOutcomeUnknownError:
             if reason == "connection_lost":
@@ -416,33 +500,61 @@ class _ViewToolSource(MCPServer):
                 )
 
         async def guarded_executor(**params: Any) -> Any:
-            permit = await connection.runtime._begin_call(
-                connection.identity,
-                entry,
-                generation=connection.generation,
-                tool=qualified_name,
-                owner=self._call_owner,
-                # Re-checked on every wake, so one message covers both a stale
-                # executor and an Agent that closed while its call was queued.
-                check_lease=check_lease,
-            )
+            try:
+                permit = await connection.runtime._begin_call(
+                    connection.identity,
+                    entry,
+                    generation=connection.generation,
+                    tool=qualified_name,
+                    owner=self._call_owner,
+                    # Re-checked on every wake, so one message covers both a stale
+                    # executor and an Agent that closed while its call was queued.
+                    check_lease=check_lease,
+                )
+            except MCPCallCapacityError:
+                connection.runtime._emit(
+                    MCPCallCapacityRejected(
+                        tenant_key=tenant_key,
+                        connection_key=connection_key,
+                        source_name=source_name,
+                        tool=qualified_name,
+                        limit=connection.runtime.max_in_flight_calls,
+                    )
+                )
+                raise
+            loop = asyncio.get_running_loop()
+            started_at = loop.time()
+            permit.started_at = started_at
+            connection.runtime._emit(_started_event())
             try:
                 result = await executor(**params)
             except asyncio.CancelledError as exc:
                 interruption = permit.interruption
                 if interruption is None:
+                    # Purely application-issued cancellation: the runtime did
+                    # not interrupt this call, but the started operation still
+                    # needs its one terminal event.
+                    connection.runtime._emit_call_terminal(
+                        permit, _cancelled_event(loop.time() - started_at)
+                    )
                     raise
                 # Absorb only the cancellation issued by MCPRuntime. If the
                 # application also cancelled this Agent task, its independent
                 # request remains and cancellation must keep propagating.
                 remaining = permit.task.uncancel()
                 permit.interruption = None
+                connection.runtime._emit_call_terminal(
+                    permit, _unknown_event(loop.time() - started_at, interruption)
+                )
                 if remaining:
                     raise
                 raise unknown_outcome(interruption) from exc
             except BaseException as exc:
                 interruption = permit.interruption
                 if interruption is not None or entry.force_evicted:
+                    connection.runtime._emit_call_terminal(
+                        permit, _unknown_event(loop.time() - started_at, interruption or "forced")
+                    )
                     if interruption is not None:
                         remaining = permit.task.uncancel()
                         permit.interruption = None
@@ -462,6 +574,9 @@ class _ViewToolSource(MCPServer):
                         entry,
                         reporting_permit=permit,
                     )
+                    connection.runtime._emit_call_terminal(
+                        permit, _unknown_event(loop.time() - started_at, "connection_lost")
+                    )
                     raise unknown_outcome("connection_lost") from exc
                 if isinstance(exc, Exception):
                     # Any ordinary tool failure arrived over a functioning
@@ -471,6 +586,15 @@ class _ViewToolSource(MCPServer):
                         connection.identity,
                         entry,
                     )
+                    connection.runtime._emit_call_terminal(
+                        permit, _failed_event(loop.time() - started_at, type(exc).__name__)
+                    )
+                else:
+                    # SystemExit or KeyboardInterrupt unwound the call: no
+                    # server verdict, but the start still gets its terminal.
+                    connection.runtime._emit_call_terminal(
+                        permit, _cancelled_event(loop.time() - started_at)
+                    )
                 raise
             else:
                 interruption = permit.interruption
@@ -478,6 +602,11 @@ class _ViewToolSource(MCPServer):
                     remaining = permit.task.uncancel()
                     permit.interruption = None
                     if remaining:
+                        # The server answered — record that truth before the
+                        # application's own cancellation takes over.
+                        connection.runtime._emit_call_terminal(
+                            permit, _completed_event(loop.time() - started_at)
+                        )
                         raise asyncio.CancelledError
                     # A normal return is a definitive server response. Forced
                     # teardown prevents future work; it does not make this
@@ -485,6 +614,9 @@ class _ViewToolSource(MCPServer):
                 connection.runtime._record_healthy_tool_response(
                     connection.identity,
                     entry,
+                )
+                connection.runtime._emit_call_terminal(
+                    permit, _completed_event(loop.time() - started_at)
                 )
                 return result
             finally:
@@ -525,13 +657,16 @@ class _ConnectionEntry:
         "broken",
         "call_permits",
         "circuit",
+        "close_terminal_emitted",
         "close_started",
         "fenced",
         "force_evicted",
         "idle_handle",
         "idle_seq",
         "info",
+        "instance_id",
         "leases",
+        "opening_terminal_emitted",
         "raw_tools",
         "retire_task",
         "source",
@@ -556,10 +691,15 @@ class _ConnectionEntry:
         self.force_evicted = False
         self.broken = False
         self.close_started = False
+        self.opening_terminal_emitted = False
+        self.close_terminal_emitted = False
         # The circuit of the registration this entry was opened under. Held
         # directly so a failure recorded by a slow attempt lands on the
         # circuit that admitted it, never on one a later rebind reset.
         self.circuit: _CircuitState | None = None
+        # Runtime-wide monotonic id of this exact physical connection, so
+        # telemetry can tell overlapping lifetimes of one identity apart.
+        self.instance_id = 0
         # Idle retirement: a pending timer, then the task closing this exact
         # physical entry. Both are scoped to this entry so a stale callback can
         # never touch a replacement connection.
@@ -574,14 +714,39 @@ class _ConnectionEntry:
 class _CallPermit:
     """Exact-once ownership of one admitted runtime-wide call slot."""
 
-    __slots__ = ("entry", "interruption", "release_event", "released", "task")
+    __slots__ = (
+        "detached",
+        "entry",
+        "identity",
+        "interruption",
+        "release_event",
+        "released",
+        "started_at",
+        "task",
+        "terminal_emitted",
+        "tool",
+    )
 
-    def __init__(self, entry: _ConnectionEntry, task: asyncio.Task[Any]) -> None:
+    def __init__(
+        self,
+        entry: _ConnectionEntry,
+        task: asyncio.Task[Any],
+        identity: tuple[str | None, str],
+        tool: str,
+    ) -> None:
         self.entry = entry
         self.task = task
+        self.identity = identity
+        self.tool = tool
         self.interruption: _CallInterruption | None = None
         self.release_event = asyncio.Event()
         self.released = False
+        self.started_at: float | None = None
+        self.terminal_emitted = False
+        # Capacity was reclaimed while the transport operation kept running;
+        # cleared when the executor finally exits, so reclaimed-but-live
+        # work stays countable.
+        self.detached = False
 
 
 class _CallWaiter:
@@ -717,6 +882,15 @@ class MCPRuntime:
     FIFO for up to ``call_wait_timeout`` and are then shed, having never been
     sent. Forced cleanup releases logical capacity after a bounded grace even
     if a hostile transport keeps its already-started operation alive.
+
+    Operational visibility is process-local, like connection-pool metrics:
+    :meth:`snapshot` returns an immutable point-in-time view (connections
+    and their statuses, in-flight calls, capacity waiters, open circuits),
+    and an optional ``observer`` receives typed lifecycle events —
+    synchronously, outside runtime locks, with failures swallowed and logged
+    value-free. Events carry tenant and connection keys for the application
+    to route, but never credentials, arguments, results, or error text; the
+    runtime's own logs name only validated source labels.
     """
 
     def __init__(
@@ -730,6 +904,7 @@ class MCPRuntime:
         shutdown_timeout: float = 30.0,
         circuit_failure_threshold: int | None = 5,
         circuit_reset_timeout: float = 30.0,
+        observer: MCPRuntimeObserver | None = None,
     ) -> None:
         self.max_connections = _positive_int(max_connections, "max_connections")
         self.max_in_flight_calls = _positive_int(
@@ -761,6 +936,24 @@ class MCPRuntime:
             else _positive_int(circuit_failure_threshold, "circuit_failure_threshold")
         )
         self.circuit_reset_timeout = _positive_float(circuit_reset_timeout, "circuit_reset_timeout")
+        if observer is not None:
+            # A runtime_checkable protocol only proves the attribute exists.
+            # An on_event that is not callable would fail every delivery, and
+            # a coroutine function would return un-awaited coroutines and
+            # silently drop every event.
+            on_event = getattr(observer, "on_event", None)
+            if not callable(on_event):
+                raise ValueError(
+                    "MCPRuntime observer must implement MCPRuntimeObserver.on_event(event)."
+                )
+            if inspect.iscoroutinefunction(on_event) or inspect.iscoroutinefunction(
+                type(on_event).__call__
+            ):
+                raise ValueError(
+                    "MCPRuntime observer on_event must be synchronous; hand events "
+                    "to a queue or task of the application's choosing instead."
+                )
+        self._observer = observer
         self._state = MCPRuntimeState.OPEN
         # The registered source is the canonical configuration for an
         # identity. evict() must remove entries here, or an evicted
@@ -782,11 +975,89 @@ class MCPRuntime:
         # process load without drifting across cancellation and forced cleanup.
         self._active_call_permits: set[_CallPermit] = set()
         self._call_queue: deque[_CallWaiter] = deque()
+        # Monotonic id source for physical connections, and the count of
+        # reclaimed permits whose transport operations are still running.
+        self._connection_seq = 0
+        self._detached_calls = 0
         self._lock = Lock()
 
     @property
     def _in_flight_calls(self) -> int:
         return len(self._active_call_permits)
+
+    def _emit(self, event: MCPRuntimeEvent | None) -> None:
+        """Deliver one event to the observer; never under a runtime lock.
+
+        Accepts ``None`` so helpers that conditionally produce an event can
+        be emitted unconditionally. Observer exceptions are swallowed and
+        logged value-free: telemetry must never break MCP work, and observer
+        errors are application-authored text that could carry anything.
+        """
+        observer = self._observer
+        if event is None or observer is None:
+            return
+        try:
+            callback: Any = observer.on_event
+            result = callback(event)
+            if inspect.isawaitable(result):
+                # A synchronous wrapper can still manufacture an awaitable at
+                # call time. Dispose of it so it cannot leak a coroutine or
+                # run outside the observer contract, then drop the event.
+                try:
+                    if isinstance(result, asyncio.Future):
+                        result.cancel()
+                    else:
+                        close = getattr(result, "close", None)
+                        if callable(close):
+                            close()
+                except BaseException:
+                    pass
+                logger.warning(
+                    "MCP runtime observer returned an awaitable handling %s; event dropped.",
+                    type(event).__name__,
+                )
+        except BaseException as exc:
+            logger.warning(
+                "MCP runtime observer failed handling %s (%s); event dropped.",
+                type(event).__name__,
+                type(exc).__name__,
+            )
+
+    def _emit_opening_terminal(
+        self,
+        entry: _ConnectionEntry,
+        event: MCPRuntimeEvent,
+    ) -> None:
+        """Emit one terminal event for an entry's connection attempt."""
+        with self._lock:
+            if entry.opening_terminal_emitted:
+                return
+            entry.opening_terminal_emitted = True
+        self._emit(event)
+
+    def _emit_close_terminal(
+        self,
+        entry: _ConnectionEntry,
+        event: MCPConnectionClosed,
+    ) -> None:
+        """Emit one close terminal for an opened physical connection."""
+        with self._lock:
+            if entry.close_terminal_emitted:
+                return
+            entry.close_terminal_emitted = True
+        self._emit(event)
+
+    def _emit_call_terminal(
+        self,
+        permit: _CallPermit,
+        event: MCPRuntimeEvent,
+    ) -> None:
+        """Emit one terminal event for an admitted tool call."""
+        with self._lock:
+            if permit.terminal_emitted:
+                return
+            permit.terminal_emitted = True
+        self._emit(event)
 
     def _bind_loop(self) -> None:
         loop = asyncio.get_running_loop()
@@ -1060,8 +1331,10 @@ class MCPRuntime:
             entry.fenced = True
         try:
             await self._teardown_entry(
+                identity,
                 entry,
                 loop=loop,
+                reason="idle",
                 cancel_warning=(
                     "MCP source '%s' connect task ignored idle cancellation; abandoning it."
                 ),
@@ -1082,7 +1355,7 @@ class MCPRuntime:
         *,
         timeout: float,
         warning: str,
-    ) -> None:
+    ) -> set[asyncio.Task[None]]:
         """Await teardown tasks, then hand resistant ones to the background.
 
         Every finished task's result is consumed so a late failure never
@@ -1090,19 +1363,22 @@ class MCPRuntime:
         tracked rather than waited on, keeping every caller bounded.
         """
         if not tasks:
-            return
+            return set()
         done, pending = await asyncio.wait(tasks, timeout=timeout)
         for task in done:
             self._consume_task_exception(task)
         for task in pending:
             logger.warning(warning, tasks[task].source.name)
             self._track_abandoned_task(task)
+        return pending
 
     async def _teardown_entry(
         self,
+        identity: tuple[str | None, str],
         entry: _ConnectionEntry,
         *,
         loop: asyncio.AbstractEventLoop,
+        reason: Literal["idle", "broken", "evicted", "shutdown"],
         cancel_warning: str,
         close_warning: str,
     ) -> None:
@@ -1114,18 +1390,47 @@ class MCPRuntime:
         task = entry.task
         if task is not None and not task.done():
             task.cancel()
-            await self._settle_teardown_tasks(
+            pending = await self._settle_teardown_tasks(
                 {task: entry},
                 timeout=_FORCED_CANCEL_GRACE,
                 warning=cancel_warning,
             )
-        await self._settle_teardown_tasks(
-            {loop.create_task(self._close_adapter(entry)): entry},
+            if task in pending:
+                self._emit_opening_terminal(
+                    entry,
+                    MCPConnectionAborted(
+                        tenant_key=identity[0],
+                        connection_key=identity[1],
+                        source_name=entry.source.name,
+                        instance_id=entry.instance_id,
+                    ),
+                )
+        close_task = loop.create_task(self._close_adapter(identity, entry, reason=reason))
+        pending = await self._settle_teardown_tasks(
+            {close_task: entry},
             timeout=_FORCED_CANCEL_GRACE,
             warning=close_warning,
         )
+        if close_task in pending and entry.adapter is not None:
+            self._emit_close_terminal(
+                entry,
+                MCPConnectionClosed(
+                    tenant_key=identity[0],
+                    connection_key=identity[1],
+                    source_name=entry.source.name,
+                    instance_id=entry.instance_id,
+                    reason=reason,
+                    clean=False,
+                ),
+            )
 
-    async def _close_adapter(self, entry: _ConnectionEntry) -> None:
+    async def _close_adapter(
+        self,
+        identity: tuple[str | None, str],
+        entry: _ConnectionEntry,
+        *,
+        reason: Literal["idle", "broken", "evicted", "shutdown"],
+    ) -> None:
         """Close an entry's transport at most once across all callers."""
         with self._lock:
             adapter = entry.adapter
@@ -1134,6 +1439,7 @@ class MCPRuntime:
             # Guards against runtime shutdown and eviction both closing the
             # same transport when they run concurrently.
             entry.close_started = True
+        clean = False
         try:
             await adapter.close()
         except Exception as exc:
@@ -1142,6 +1448,23 @@ class MCPRuntime:
                 entry.source.name,
                 safe_source_exception_detail(adapter.source, exc),
                 type(exc).__name__,
+            )
+        else:
+            clean = True
+        finally:
+            # Whoever wins the close_started race reports the one close event.
+            # A teardown owner may already have terminalized a resistant close
+            # as unclean before allowing this task to finish in the background.
+            self._emit_close_terminal(
+                entry,
+                MCPConnectionClosed(
+                    tenant_key=identity[0],
+                    connection_key=identity[1],
+                    source_name=entry.source.name,
+                    instance_id=entry.instance_id,
+                    reason=reason,
+                    clean=clean,
+                ),
             )
 
     def _circuit_retry_after(self, circuit: _CircuitState, now: float) -> float | None:
@@ -1185,12 +1508,13 @@ class MCPRuntime:
         cause: str,
         *,
         connection_lost: bool = False,
-    ) -> None:
+    ) -> MCPCircuitOpened | None:
         """Count one connection failure toward the entry's circuit.
 
         ``cause`` must be value-free (an exception class name or a fixed
         phrase): it is rendered into rejection messages and logs. Caller
-        must hold the runtime lock.
+        must hold the runtime lock; a returned open event must be emitted
+        after releasing it.
         """
         circuit = entry.circuit
         threshold = self.circuit_failure_threshold
@@ -1199,13 +1523,13 @@ class MCPRuntime:
             or threshold is None
             or not self._entry_owns_current_circuit(identity, entry)
         ):
-            return
+            return None
         circuit.consecutive_failures += 1
         if connection_lost:
             circuit.connection_loss_failures += 1
         circuit.last_failure = cause
         if circuit.consecutive_failures < threshold or self._loop is None:
-            return
+            return None
         circuit.open_until = self._loop.time() + self.circuit_reset_timeout
         logger.warning(
             "MCP source '%s' circuit opened after %d consecutive connection "
@@ -1215,26 +1539,45 @@ class MCPRuntime:
             cause,
             self.circuit_reset_timeout,
         )
+        tenant_key, connection_key = identity
+        return MCPCircuitOpened(
+            tenant_key=tenant_key,
+            connection_key=connection_key,
+            source_name=entry.source.name,
+            failure_count=circuit.consecutive_failures,
+            last_failure=circuit.last_failure,
+            reset_timeout=self.circuit_reset_timeout,
+        )
 
     def _record_circuit_connection_success(
         self,
         identity: tuple[str | None, str],
         entry: _ConnectionEntry,
-    ) -> None:
+    ) -> MCPCircuitClosed | None:
         """Record a successful handshake without hiding unstable sessions.
 
         Establishment clears connection-attempt failures. Mid-call losses
         survive until a real tool response proves the replacement session is
         healthy; otherwise a server that accepts discovery but drops every
         call could reconnect forever without opening its circuit. Caller must
-        hold the runtime lock.
+        hold the runtime lock; a returned close event must be emitted after
+        releasing it.
         """
         circuit = entry.circuit
         if circuit is None or not self._entry_owns_current_circuit(identity, entry):
-            return
+            return None
+        was_open = circuit.open_until is not None
         circuit.consecutive_failures = circuit.connection_loss_failures
         circuit.last_failure = "connection loss" if circuit.connection_loss_failures else None
         circuit.open_until = None
+        if not was_open:
+            return None
+        tenant_key, connection_key = identity
+        return MCPCircuitClosed(
+            tenant_key=tenant_key,
+            connection_key=connection_key,
+            source_name=entry.source.name,
+        )
 
     def _record_healthy_tool_response(
         self,
@@ -1242,14 +1585,22 @@ class MCPRuntime:
         entry: _ConnectionEntry,
     ) -> None:
         """Reset the circuit after a confirmed response on the live entry."""
+        circuit_closed: MCPCircuitClosed | None = None
         with self._lock:
             circuit = entry.circuit
-            if circuit is None or not self._entry_owns_current_circuit(identity, entry):
-                return
-            circuit.consecutive_failures = 0
-            circuit.connection_loss_failures = 0
-            circuit.last_failure = None
-            circuit.open_until = None
+            if circuit is not None and self._entry_owns_current_circuit(identity, entry):
+                if circuit.open_until is not None:
+                    tenant_key, connection_key = identity
+                    circuit_closed = MCPCircuitClosed(
+                        tenant_key=tenant_key,
+                        connection_key=connection_key,
+                        source_name=entry.source.name,
+                    )
+                circuit.consecutive_failures = 0
+                circuit.connection_loss_failures = 0
+                circuit.last_failure = None
+                circuit.open_until = None
+        self._emit(circuit_closed)
 
     def _connection_lost(
         self,
@@ -1268,13 +1619,14 @@ class MCPRuntime:
         reconnects — resolving fresh credentials — on its next acquisition.
         """
         released = False
+        circuit_opened: MCPCircuitOpened | None = None
         with self._lock:
             if self._entries.get(identity) is not entry:
                 return
             if not entry.fenced:
                 if self._state is not MCPRuntimeState.OPEN or self._loop is None:
                     return  # shutdown already tears every transport down
-                self._record_circuit_failure(
+                circuit_opened = self._record_circuit_failure(
                     identity,
                     entry,
                     "connection loss",
@@ -1292,6 +1644,7 @@ class MCPRuntime:
             # queued for this dead entry, never admit one onto its transport.
             released = self._release_call_permit(identity, reporting_permit)
             self._wake_call_waiters_for_entry(entry)
+        self._emit(circuit_opened)
         if released:
             self._notify_drain()
 
@@ -1315,8 +1668,10 @@ class MCPRuntime:
                 interruption="connection_lost",
             )
             await self._teardown_entry(
+                identity,
                 entry,
                 loop=loop,
+                reason="broken",
                 cancel_warning=(
                     "MCP source '%s' connect task ignored recovery cancellation; abandoning it."
                 ),
@@ -1341,6 +1696,7 @@ class MCPRuntime:
         identity = connection.identity
         admission: _Admission | None = None
         deadline: float | None = None
+        probe_event: MCPCircuitProbing | None = None
         loop = asyncio.get_running_loop()
         try:
             while True:
@@ -1396,8 +1752,18 @@ class MCPRuntime:
                                 last_failure=circuit.last_failure,
                             )
                         if self._can_admit(admission):
+                            if registration.circuit.open_until is not None:
+                                # Cooldown elapsed but not yet cleared: this
+                                # acquisition is the half-open probe.
+                                probe_event = MCPCircuitProbing(
+                                    tenant_key=identity[0],
+                                    connection_key=identity[1],
+                                    source_name=registration.source.name,
+                                )
                             entry = _ConnectionEntry(registration.source)
                             entry.circuit = registration.circuit
+                            self._connection_seq += 1
+                            entry.instance_id = self._connection_seq
                             entry.task = loop.create_task(
                                 self._open_connection(
                                     identity,
@@ -1434,12 +1800,24 @@ class MCPRuntime:
                     await asyncio.wait_for(waiter.wait(), timeout=remaining)
                 except TimeoutError:
                     continue  # re-check under the lock, then raise the capacity error
+        except MCPConnectionCapacityError:
+            # The raise released the lock; the callback must stay outside it.
+            self._emit(
+                MCPConnectionCapacityRejected(
+                    tenant_key=identity[0],
+                    connection_key=identity[1],
+                    source_name=connection.source.name,
+                    limit=self.max_connections,
+                )
+            )
+            raise
         finally:
             if admission is not None:
                 with self._lock:
                     self._release_admission(admission)
 
         assert task is not None
+        self._emit(probe_event)
         try:
             # Shielded: cancelling this caller must not cancel connection
             # establishment for concurrent leases of the same identity.
@@ -1463,6 +1841,15 @@ class MCPRuntime:
         the provider is consulted exactly once per physical connection.
         """
         adapter: MCPClientAdapter | None = None
+        tenant_key, connection_key = identity
+        self._emit(
+            MCPConnectionOpening(
+                tenant_key=tenant_key,
+                connection_key=connection_key,
+                source_name=entry.source.name,
+                instance_id=entry.instance_id,
+            )
+        )
         try:
             source = entry.source
             if credentials is not None:
@@ -1471,15 +1858,43 @@ class MCPRuntime:
             await adapter.connect()
             raw_tools = await adapter.list_tools()
         except BaseException as exc:
+            circuit_opened: MCPCircuitOpened | None = None
+            failure_cause: str | None = None
             with self._lock:
                 # A cancelled attempt is a verdict about this runtime's
                 # teardown, not about the server: only real failures count.
                 if isinstance(exc, Exception) and not isinstance(exc, asyncio.CancelledError):
-                    self._record_circuit_failure(identity, entry, type(exc).__name__)
+                    failure_cause = type(exc).__name__
+                    circuit_opened = self._record_circuit_failure(identity, entry, failure_cause)
                 if self._entries.get(identity) is entry and not entry.fenced:
                     # Discard so the identity can be retried with a fresh entry,
                     # freeing its slot and any idle timer a departed waiter armed.
                     self._discard_entry(identity, entry)
+            if failure_cause is not None:
+                self._emit_opening_terminal(
+                    entry,
+                    MCPConnectionFailed(
+                        tenant_key=tenant_key,
+                        connection_key=connection_key,
+                        source_name=entry.source.name,
+                        instance_id=entry.instance_id,
+                        cause=failure_cause,
+                    ),
+                )
+            else:
+                # Cancelled by teardown or unwound by process control flow:
+                # no server verdict, but the started attempt needs its one
+                # terminal event.
+                self._emit_opening_terminal(
+                    entry,
+                    MCPConnectionAborted(
+                        tenant_key=tenant_key,
+                        connection_key=connection_key,
+                        source_name=entry.source.name,
+                        instance_id=entry.instance_id,
+                    ),
+                )
+            self._emit(circuit_opened)
             if adapter is not None:
                 try:
                     await adapter.close()
@@ -1492,7 +1907,7 @@ class MCPRuntime:
                     )
             raise
         with self._lock:
-            self._record_circuit_connection_success(identity, entry)
+            circuit_closed = self._record_circuit_connection_success(identity, entry)
             # A force-closed or evicted entry must never receive a live
             # adapter: a transport that suppressed cancellation could
             # otherwise publish into an already-closed runtime.
@@ -1501,6 +1916,18 @@ class MCPRuntime:
                 entry.adapter = adapter
                 entry.raw_tools = list(raw_tools)
                 entry.info = adapter.info
+        if still_current:
+            self._emit_opening_terminal(
+                entry,
+                MCPConnectionOpened(
+                    tenant_key=tenant_key,
+                    connection_key=connection_key,
+                    source_name=entry.source.name,
+                    instance_id=entry.instance_id,
+                    tool_count=len(entry.raw_tools),
+                ),
+            )
+            self._emit(circuit_closed)
         if not still_current:
             try:
                 await adapter.close()
@@ -1511,6 +1938,17 @@ class MCPRuntime:
                     safe_source_exception_detail(adapter.source, exc),
                     type(exc).__name__,
                 )
+            # Established, but only after losing its slot: never served and
+            # never published, so the attempt terminates as aborted.
+            self._emit_opening_terminal(
+                entry,
+                MCPConnectionAborted(
+                    tenant_key=tenant_key,
+                    connection_key=connection_key,
+                    source_name=entry.source.name,
+                    instance_id=entry.instance_id,
+                ),
+            )
             raise MCPConnectionError(
                 f"MCP source '{entry.source.name}' connection was released before "
                 "establishment completed."
@@ -1663,7 +2101,7 @@ class MCPRuntime:
                     if self._can_start_call(waiter):
                         task = asyncio.current_task()
                         assert task is not None
-                        permit = _CallPermit(entry, task)
+                        permit = _CallPermit(entry, task, identity, tool)
                         self._active_call_permits.add(permit)
                         entry.call_permits.add(permit)
                         entry.active_calls += 1
@@ -1704,6 +2142,10 @@ class MCPRuntime:
         with self._lock:
             self._bind_loop()
             released = self._release_call_permit(identity, permit)
+            if permit.detached:
+                # The reclaimed call's executor has finally exited.
+                permit.detached = False
+                self._detached_calls -= 1
         if released:
             self._notify_drain()
 
@@ -1780,8 +2222,29 @@ class MCPRuntime:
         released = False
         with self._lock:
             resistant = [permit for _, permit in owned if not permit.released]
+            for permit in resistant:
+                # Capacity is reclaimed below, but the transport operation is
+                # still running; count it as detached until its executor exits.
+                permit.detached = True
+                self._detached_calls += 1
             for identity, permit in owned:
                 released = self._release_call_permit(identity, permit) or released
+        now = asyncio.get_running_loop().time()
+        for permit in resistant:
+            started_at = permit.started_at if permit.started_at is not None else now
+            reason = permit.interruption or interruption
+            self._emit_call_terminal(
+                permit,
+                MCPToolCallOutcomeUnknown(
+                    tenant_key=permit.identity[0],
+                    connection_key=permit.identity[1],
+                    source_name=permit.entry.source.name,
+                    instance_id=permit.entry.instance_id,
+                    tool=permit.tool,
+                    duration=max(now - started_at, 0.0),
+                    reason=reason,
+                ),
+            )
         if released:
             self._notify_drain()
         if resistant:
@@ -1803,6 +2266,66 @@ class MCPRuntime:
         """Return the current application-owned lifecycle state."""
         with self._lock:
             return self._state
+
+    @staticmethod
+    def _entry_status(entry: _ConnectionEntry) -> MCPConnectionStatus:
+        """Classify one entry for a snapshot. Caller must hold the lock."""
+        if entry.broken:
+            return MCPConnectionStatus.BROKEN
+        if entry.fenced or entry.retire_task is not None:
+            return MCPConnectionStatus.CLOSING
+        if entry.adapter is None:
+            return MCPConnectionStatus.CONNECTING
+        if entry.leases or entry.active_calls:
+            return MCPConnectionStatus.ACTIVE
+        return MCPConnectionStatus.IDLE
+
+    def snapshot(self) -> MCPRuntimeSnapshot:
+        """Return an immutable point-in-time view of runtime health.
+
+        Taken atomically under one lock acquisition and safe to call from
+        any thread — a metrics scraper does not need the event loop.
+        ``connections`` lists physical connections; ``open_circuits`` lists
+        registered identities currently rejecting new connections, which
+        typically have no physical connection at all.
+        """
+        with self._lock:
+            now = self._loop.time() if self._loop is not None else 0.0
+            connections = tuple(
+                MCPConnectionSnapshot(
+                    tenant_key=tenant_key,
+                    connection_key=connection_key,
+                    source_name=entry.source.name,
+                    instance_id=entry.instance_id,
+                    status=self._entry_status(entry),
+                    leases=entry.leases,
+                    active_calls=entry.active_calls,
+                )
+                for (tenant_key, connection_key), entry in self._entries.items()
+            )
+            open_circuits = tuple(
+                MCPOpenCircuitSnapshot(
+                    tenant_key=tenant_key,
+                    connection_key=connection_key,
+                    source_name=registration.source.name,
+                    failure_count=registration.circuit.consecutive_failures,
+                    last_failure=registration.circuit.last_failure,
+                    retry_after=max(registration.circuit.open_until - now, 0.0),
+                )
+                for (tenant_key, connection_key), registration in self._registrations.items()
+                if registration.circuit.open_until is not None
+            )
+            return MCPRuntimeSnapshot(
+                state=self._state,
+                connections=connections,
+                in_flight_calls=len(self._active_call_permits),
+                detached_calls=self._detached_calls,
+                connection_waiters=sum(
+                    admission.waiters for admission in self._admissions.values()
+                ),
+                call_waiters=len(self._call_queue),
+                open_circuits=open_circuits,
+            )
 
     def bind(
         self,
@@ -1952,6 +2475,7 @@ class MCPRuntime:
 
         identity = tenant_key, connection_key
         shutdown_task: asyncio.Task[None] | None = None
+        started_event: MCPEvictionStarted | None = None
         with self._lock:
             if self._state is MCPRuntimeState.CLOSED:
                 return
@@ -2006,6 +2530,13 @@ class MCPRuntime:
                         )
                     )
                     self._evictions[identity] = task
+                    started_event = MCPEvictionStarted(
+                        tenant_key=tenant_key,
+                        connection_key=connection_key,
+                        source_name=entry.source.name,
+                        mode=mode,
+                    )
+        self._emit(started_event)
         if escalate:
             # Wake the in-flight drain so it stops waiting for live work.
             self._notify_drain()
@@ -2046,8 +2577,10 @@ class MCPRuntime:
             if entry.force_evicted:
                 await self._interrupt_active_calls({identity: entry})
             await self._teardown_entry(
+                identity,
                 entry,
                 loop=loop,
+                reason="evicted",
                 cancel_warning=(
                     "MCP source '%s' connect task ignored eviction cancellation; abandoning it."
                 ),
@@ -2066,6 +2599,14 @@ class MCPRuntime:
                     del self._registrations[identity]
                 self._evictions.pop(identity, None)
             self._notify_drain()
+            self._emit(
+                MCPEvictionCompleted(
+                    tenant_key=identity[0],
+                    connection_key=identity[1],
+                    source_name=entry.source.name,
+                    forced=entry.force_evicted,
+                )
+            )
 
     async def close(self) -> None:
         """Drain active leases, then start bounded transport cleanup.
@@ -2075,6 +2616,7 @@ class MCPRuntime:
         force-evicted. A transport that resists cancellation or close is
         retained and observed until its cleanup task eventually finishes.
         """
+        started = False
         with self._lock:
             self._bind_loop()
             if self._close_task is None:
@@ -2086,7 +2628,10 @@ class MCPRuntime:
                     admission.event.set()
                 self._wake_all_call_waiters()
                 self._close_task = asyncio.get_running_loop().create_task(self._close_impl())
+                started = True
             task = self._close_task
+        if started:
+            self._emit(MCPRuntimeShutdownStarted())
         # Shielded so one cancelled caller cannot abort the shared shutdown.
         await asyncio.shield(task)
 
@@ -2103,7 +2648,8 @@ class MCPRuntime:
         drained = await self._wait_for_quiet(deadline, quiet)
 
         with self._lock:
-            entries = list(self._entries.values())
+            entry_items = list(self._entries.items())
+            entries = [entry for _, entry in entry_items]
             for entry in entries:
                 self._cancel_idle(entry)
                 entry.fenced = True
@@ -2130,7 +2676,7 @@ class MCPRuntime:
         # Unlike per-entry teardown, shutdown shares one grace window across
         # every connection. Applying it once per entry would make forced
         # shutdown scale linearly with the number of resistant transports.
-        await self._settle_teardown_tasks(
+        pending_connect_tasks = await self._settle_teardown_tasks(
             connect_tasks,
             timeout=max(deadline - loop.time(), _FORCED_CANCEL_GRACE),
             warning=(
@@ -2138,18 +2684,46 @@ class MCPRuntime:
                 "shutdown budget; abandoning it."
             ),
         )
-        await self._settle_teardown_tasks(
-            {
-                loop.create_task(self._close_adapter(entry)): entry
-                for entry in entries
-                if entry.adapter is not None
-            },
+        identity_by_entry = {entry: identity for identity, entry in entry_items}
+        for task in pending_connect_tasks:
+            entry = connect_tasks[task]
+            identity = identity_by_entry[entry]
+            self._emit_opening_terminal(
+                entry,
+                MCPConnectionAborted(
+                    tenant_key=identity[0],
+                    connection_key=identity[1],
+                    source_name=entry.source.name,
+                    instance_id=entry.instance_id,
+                ),
+            )
+        close_tasks = {
+            loop.create_task(self._close_adapter(identity, entry, reason="shutdown")): entry
+            for identity, entry in entry_items
+            if entry.adapter is not None
+        }
+        pending_close_tasks = await self._settle_teardown_tasks(
+            close_tasks,
             timeout=_FORCED_CANCEL_GRACE,
             warning=(
                 "MCP source '%s' connection cleanup exceeded the shutdown grace; "
                 "allowing it to finish in the background."
             ),
         )
+        for task in pending_close_tasks:
+            entry = close_tasks[task]
+            identity = identity_by_entry[entry]
+            self._emit_close_terminal(
+                entry,
+                MCPConnectionClosed(
+                    tenant_key=identity[0],
+                    connection_key=identity[1],
+                    source_name=entry.source.name,
+                    instance_id=entry.instance_id,
+                    reason="shutdown",
+                    clean=False,
+                ),
+            )
         if pending_tasks:
             # Evictions and idle retirements own entries too; let them finish
             # before the runtime declares itself closed.
@@ -2169,6 +2743,7 @@ class MCPRuntime:
             self._entries.clear()
             self._registrations.clear()
             self._state = MCPRuntimeState.CLOSED
+        self._emit(MCPRuntimeShutdownCompleted(forced=bool(forced_entries)))
 
     async def __aenter__(self) -> MCPRuntime:
         return self

--- a/packages/python/src/dendrux/mcp/_runtime.py
+++ b/packages/python/src/dendrux/mcp/_runtime.py
@@ -21,6 +21,7 @@ from dendrux.mcp._errors import (
     MCPConnectionCapacityError,
     MCPConnectionError,
     MCPConnectionEvictingError,
+    MCPConnectionLostError,
     MCPCredentialError,
     MCPOutcomeUnknownError,
     MCPRuntimeClosedError,
@@ -49,6 +50,7 @@ _FORCED_CANCEL_GRACE = 0.05
 
 
 MCPEvictionMode = Literal["drain", "force"]
+_CallInterruption = Literal["forced", "connection_lost"]
 
 
 class MCPRuntimeState(StrEnum):
@@ -391,7 +393,13 @@ class _ViewToolSource(MCPServer):
         connection = self._view.connection
         qualified_name = f"{self.name}__{mcp_tool_name}"
 
-        def unknown_outcome() -> MCPOutcomeUnknownError:
+        def unknown_outcome(reason: _CallInterruption) -> MCPOutcomeUnknownError:
+            if reason == "connection_lost":
+                return MCPOutcomeUnknownError(
+                    f"MCP tool '{qualified_name}' was interrupted by a lost connection. "
+                    "The server may already have applied it, so it must not be retried "
+                    "automatically. The next acquisition opens a fresh connection."
+                )
             return MCPOutcomeUnknownError(
                 f"MCP tool '{qualified_name}' was interrupted by a forced eviction. "
                 "The server may already have applied it, so it must not be retried "
@@ -410,6 +418,7 @@ class _ViewToolSource(MCPServer):
             permit = await connection.runtime._begin_call(
                 connection.identity,
                 entry,
+                generation=connection.generation,
                 tool=qualified_name,
                 owner=self._call_owner,
                 # Re-checked on every wake, so one message covers both a stale
@@ -419,32 +428,46 @@ class _ViewToolSource(MCPServer):
             try:
                 result = await executor(**params)
             except asyncio.CancelledError as exc:
-                if not permit.interrupted:
+                interruption = permit.interruption
+                if interruption is None:
                     raise
                 # Absorb only the cancellation issued by MCPRuntime. If the
                 # application also cancelled this Agent task, its independent
                 # request remains and cancellation must keep propagating.
                 remaining = permit.task.uncancel()
-                permit.interrupted = False
+                permit.interruption = None
                 if remaining:
                     raise
-                raise unknown_outcome() from exc
+                raise unknown_outcome(interruption) from exc
             except BaseException as exc:
-                if entry.force_evicted:
-                    if permit.interrupted:
+                interruption = permit.interruption
+                if interruption is not None or entry.force_evicted:
+                    if interruption is not None:
                         remaining = permit.task.uncancel()
-                        permit.interrupted = False
+                        permit.interruption = None
                         # A non-zero remainder is an application cancellation.
                         # Raise it now instead of letting the unrelated tool
                         # failure hide it until some later suspension point.
                         if remaining:
                             raise asyncio.CancelledError from exc
-                    raise unknown_outcome() from exc
+                    raise unknown_outcome(interruption or "forced") from exc
+                if isinstance(exc, MCPToolCallError) and exc.connection_lost:
+                    # The transport died underneath this call. The request may
+                    # already have reached the server, so the outcome is
+                    # unknown and must not be retried automatically. Recovery
+                    # only fences the entry so future acquisitions reconnect.
+                    connection.runtime._connection_lost(
+                        connection.identity,
+                        entry,
+                        reporting_permit=permit,
+                    )
+                    raise unknown_outcome("connection_lost") from exc
                 raise
             else:
-                if permit.interrupted:
+                interruption = permit.interruption
+                if interruption is not None:
                     remaining = permit.task.uncancel()
-                    permit.interrupted = False
+                    permit.interruption = None
                     if remaining:
                         raise asyncio.CancelledError
                     # A normal return is a definitive server response. Forced
@@ -486,6 +509,7 @@ class _ConnectionEntry:
     __slots__ = (
         "active_calls",
         "adapter",
+        "broken",
         "call_permits",
         "close_started",
         "fenced",
@@ -511,9 +535,12 @@ class _ConnectionEntry:
         self.task: asyncio.Task[None] | None = None
         # fenced: no new leases or calls may be taken on this entry. Set by
         # eviction, idle retirement, and shutdown alike. force_evicted is
-        # narrower: work was interrupted, so outcomes are unknown.
+        # narrower: work was interrupted, so outcomes are unknown. broken is
+        # narrower still: the transport itself died, so calls that never
+        # started are rejected as safely retryable after re-acquisition.
         self.fenced = False
         self.force_evicted = False
+        self.broken = False
         self.close_started = False
         # Idle retirement: a pending timer, then the task closing this exact
         # physical entry. Both are scoped to this entry so a stale callback can
@@ -529,12 +556,12 @@ class _ConnectionEntry:
 class _CallPermit:
     """Exact-once ownership of one admitted runtime-wide call slot."""
 
-    __slots__ = ("entry", "interrupted", "release_event", "released", "task")
+    __slots__ = ("entry", "interruption", "release_event", "released", "task")
 
     def __init__(self, entry: _ConnectionEntry, task: asyncio.Task[Any]) -> None:
         self.entry = entry
         self.task = task
-        self.interrupted = False
+        self.interruption: _CallInterruption | None = None
         self.release_event = asyncio.Event()
         self.released = False
 
@@ -603,7 +630,7 @@ class MCPRuntime:
     Connect and discovery are lazy and single-flight; Agents lease the
     shared connection through tool views and release on ``Agent.close()``.
 
-    A connection leaves the runtime in one of three ways:
+    A connection leaves the runtime in one of four ways:
 
     * **Idle retirement** — after ``idle_timeout`` seconds with no leases and
       no in-flight calls, the transport closes but the registration and its
@@ -611,6 +638,14 @@ class MCPRuntime:
       ``idle_timeout=None`` to disable timed retirement; capacity pressure may
       still retire an idle connection. ``0`` retires as soon as the last lease
       is released.
+    * **Broken-connection recovery** — a tool call that fails with a
+      classified transport loss fences the connection immediately and retires
+      it like idle retirement: the registration survives and the next
+      acquisition reconnects with freshly resolved credentials. The failed
+      call raises :class:`MCPOutcomeUnknownError` — the server may already
+      have received it — and is never retried automatically; calls that never
+      started raise :class:`MCPConnectionLostError` and are safe to retry
+      after re-acquisition.
     * **Eviction** — :meth:`evict` closes the transport *and* forgets the
       registration, permanently invalidating every handle issued for it.
     * **Shutdown** — :meth:`close` drains, then tears everything down.
@@ -1041,6 +1076,80 @@ class MCPRuntime:
                 type(exc).__name__,
             )
 
+    def _connection_lost(
+        self,
+        identity: tuple[str | None, str],
+        entry: _ConnectionEntry,
+        *,
+        reporting_permit: _CallPermit,
+    ) -> None:
+        """Fence one broken physical entry and start its single recovery.
+
+        Reported by every call that fails with a classified transport loss;
+        the fence check makes concurrent reports converge on one recovery
+        operation. Eviction, retirement, and shutdown own the entries they
+        have already fenced, so a loss reported then changes nothing. The
+        registration and its generation are untouched: the same handle
+        reconnects — resolving fresh credentials — on its next acquisition.
+        """
+        released = False
+        with self._lock:
+            if self._entries.get(identity) is not entry:
+                return
+            if not entry.fenced:
+                if self._state is not MCPRuntimeState.OPEN or self._loop is None:
+                    return  # shutdown already tears every transport down
+                entry.broken = True
+                entry.fenced = True
+                self._cancel_idle(entry)
+                entry.retire_task = self._loop.create_task(self._retire_broken(identity, entry))
+            if not entry.broken:
+                return  # eviction or shutdown owns the fenced entry
+
+            # Fence first, then return the reporting call's slot. Pumping the
+            # global queue from _release_call_permit can now only reject calls
+            # queued for this dead entry, never admit one onto its transport.
+            released = self._release_call_permit(identity, reporting_permit)
+            self._wake_call_waiters_for_entry(entry)
+        if released:
+            self._notify_drain()
+
+    async def _retire_broken(
+        self,
+        identity: tuple[str | None, str],
+        entry: _ConnectionEntry,
+    ) -> None:
+        """Close a broken connection while keeping its identity bindable.
+
+        Unlike idle retirement this runs while leases and calls still
+        reference the entry: the transport is already dead, so waiting for a
+        drain would only delay the replacement. Admitted calls are interrupted
+        with unknown outcomes before teardown; queued calls were never sent
+        and are rejected as safely retryable.
+        """
+        loop = asyncio.get_running_loop()
+        try:
+            await self._interrupt_active_calls(
+                {identity: entry},
+                interruption="connection_lost",
+            )
+            await self._teardown_entry(
+                entry,
+                loop=loop,
+                cancel_warning=(
+                    "MCP source '%s' connect task ignored recovery cancellation; abandoning it."
+                ),
+                close_warning=(
+                    "MCP source '%s' broken-connection cleanup exceeded its grace; "
+                    "allowing it to finish in the background."
+                ),
+            )
+        finally:
+            with self._lock:
+                self._discard_entry(identity, entry)
+                entry.retire_task = None
+            self._notify_drain()
+
     async def _lease(self, connection: MCPConnection) -> _ConnectionEntry:
         """Lease the shared physical connection, opening it single-flight.
 
@@ -1290,6 +1399,7 @@ class MCPRuntime:
         self,
         identity: tuple[str | None, str],
         entry: _ConnectionEntry,
+        generation: int,
         check_lease: Callable[[], None],
     ) -> None:
         """Reject a call whose lease, runtime, or connection is gone.
@@ -1307,6 +1417,19 @@ class MCPRuntime:
                 identity,
                 f"MCP connection {identity!r} is being evicted and cannot start tool calls.",
             )
+        registration = self._registrations.get(identity)
+        if registration is None or registration.generation != generation:
+            raise MCPStaleConnectionError(
+                identity,
+                f"MCP connection handle {identity!r} is no longer registered; it was "
+                "evicted or never bound. Bind again and use the new handle.",
+            )
+        if entry.broken:
+            raise MCPConnectionLostError(
+                identity,
+                f"MCP connection {identity!r} lost its transport. This call was "
+                "never sent; acquire tools again to reconnect and retry safely.",
+            )
         if self._entries.get(identity) is not entry or entry.adapter is None or entry.fenced:
             raise MCPStaleConnectionError(
                 identity,
@@ -1319,6 +1442,7 @@ class MCPRuntime:
         identity: tuple[str | None, str],
         entry: _ConnectionEntry,
         *,
+        generation: int,
         tool: str,
         owner: object,
         check_lease: Callable[[], None],
@@ -1337,7 +1461,7 @@ class MCPRuntime:
             while True:
                 with self._lock:
                     self._bind_loop()
-                    self._check_call_state(identity, entry, check_lease)
+                    self._check_call_state(identity, entry, generation, check_lease)
                     if self._can_start_call(waiter):
                         task = asyncio.current_task()
                         assert task is not None
@@ -1411,8 +1535,10 @@ class MCPRuntime:
     async def _interrupt_active_calls(
         self,
         entries: dict[tuple[str | None, str], _ConnectionEntry],
+        *,
+        interruption: _CallInterruption = "forced",
     ) -> None:
-        """Cancel forced calls and reclaim resistant permits after one grace.
+        """Interrupt admitted calls and reclaim resistant permits after one grace.
 
         Physical execution may outlive the grace when a transport suppresses
         cancellation. The connection is already fenced and its result is
@@ -1432,7 +1558,7 @@ class MCPRuntime:
         # permit still belongs to a task suspended inside its executor, so the
         # runtime-issued cancellation is attributable without racing release.
         for _, permit in owned:
-            if permit.interrupted:
+            if permit.interruption is not None:
                 # A forced eviction and a forced shutdown can both reach the
                 # same permit inside one grace. At most one runtime-issued
                 # cancellation may be outstanding, or the executor's uncancel()
@@ -1440,7 +1566,7 @@ class MCPRuntime:
                 # re-raise CancelledError — telling the caller that nothing
                 # happened when the outcome is in fact unknown.
                 continue
-            permit.interrupted = True
+            permit.interruption = interruption
             permit.task.cancel()
 
         release_waiters = [asyncio.create_task(permit.release_event.wait()) for _, permit in owned]
@@ -1466,11 +1592,12 @@ class MCPRuntime:
             # automatic library logs.
             sources = ", ".join(sorted({permit.entry.source.name for permit in resistant}))
             logger.warning(
-                "%d MCP tool call(s) on source(s) %s ignored forced cancellation; "
+                "%d MCP tool call(s) on source(s) %s ignored %s cancellation; "
                 "releasing their runtime slots while their callers remain responsible "
                 "for eventual task completion.",
                 len(resistant),
                 sources,
+                "forced" if interruption == "forced" else "connection-recovery",
             )
 
     @property

--- a/packages/python/src/dendrux/mcp/_server.py
+++ b/packages/python/src/dendrux/mcp/_server.py
@@ -7,7 +7,7 @@ import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
-from dendrux.mcp._client import MCPClientAdapter
+from dendrux.mcp._client import MCPClientAdapter, is_connection_loss
 from dendrux.mcp._errors import MCPToolCallError
 from dendrux.mcp._result import normalize_mcp_result
 from dendrux.mcp._source import (
@@ -175,9 +175,11 @@ def create_mcp_executor(
             if opaque
             else redact_source_text(adapter.source, str(failure)) or type(failure).__name__
         )
-        raise MCPToolCallError(
-            f"MCP tool '{namespace}__{mcp_tool_name}' call failed: {detail}"
-        ) from None
+        error = MCPToolCallError(f"MCP tool '{namespace}__{mcp_tool_name}' call failed: {detail}")
+        # The managed runtime consults this to fence a dead transport; a tool
+        # that merely failed must never poison the shared connection.
+        error.connection_lost = is_connection_loss(failure)
+        raise error from None
 
     return executor
 

--- a/packages/python/src/dendrux/mcp/_server.py
+++ b/packages/python/src/dendrux/mcp/_server.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import logging
 import re
+from collections.abc import Callable, Mapping, Sequence  # noqa: TC003
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any, cast
 
 from dendrux.mcp._client import MCPClientAdapter, is_connection_loss
 from dendrux.mcp._errors import MCPToolCallError
@@ -19,9 +20,6 @@ from dendrux.mcp._source import (
     source_has_opaque_credentials,
 )
 from dendrux.types import ToolDef, ToolTarget
-
-if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping, Sequence
 
 logger = logging.getLogger(__name__)
 

--- a/packages/python/src/dendrux/mcp/_source.py
+++ b/packages/python/src/dendrux/mcp/_source.py
@@ -3,14 +3,15 @@
 from __future__ import annotations
 
 import re
+
+# Public class and factory annotations are resolved at runtime by
+# documentation and dependency-injection tooling.
+from collections.abc import Mapping, Sequence  # noqa: TC003
 from dataclasses import dataclass, field
 from pathlib import Path
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, Literal
 from urllib.parse import parse_qsl, unquote_plus, urlsplit, urlunsplit
-
-if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
 
 MCPFailureMode = Literal["strict", "best_effort"]
 MCPPhysicalIdentity = (

--- a/packages/python/tests/unit/test_mcp_client.py
+++ b/packages/python/tests/unit/test_mcp_client.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import patch
 
+import anyio
+import httpx2
 import pytest
-from mcp.types import CallToolResult, TextContent
+from mcp.shared.exceptions import MCPError as SDKMCPError
+from mcp.types import CONNECTION_CLOSED, REQUEST_TIMEOUT, CallToolResult, TextContent
 
 from dendrux.mcp import MCPServer
-from dendrux.mcp._client import MCPClientAdapter
+from dendrux.mcp._client import MCPClientAdapter, is_connection_loss
 from dendrux.mcp._errors import (
     MCPAuthenticationError,
     MCPConnectionError,
@@ -524,3 +527,101 @@ async def test_successful_structured_result_is_recursively_scrubbed() -> None:
         "nested": ["[redacted]", {"[redacted]": "[redacted]"}],
         "safe": 42,
     }
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        ConnectionResetError("peer reset"),
+        BrokenPipeError("pipe closed"),
+        ConnectionError("connection refused"),
+        EOFError(),
+        httpx2.ReadError("socket closed"),
+        httpx2.ConnectError("no route to host"),
+        httpx2.CloseError("close failed"),
+        httpx2.WriteError("send failed"),
+        httpx2.RemoteProtocolError("server disconnected without response"),
+        anyio.BrokenResourceError(),
+        anyio.ClosedResourceError(),
+        anyio.EndOfStream(),
+    ],
+)
+def test_transport_death_is_classified_as_connection_loss(error: BaseException) -> None:
+    assert is_connection_loss(error)
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        ValueError("bad arguments"),
+        RuntimeError("tool exploded"),
+        TimeoutError(),
+        httpx2.ReadTimeout("slow server"),
+        httpx2.ConnectTimeout("slow handshake"),
+        httpx2.PoolTimeout("pool exhausted"),
+        httpx2.LocalProtocolError("client-side bug"),
+        _HTTPStatusError("401 Unauthorized", 401),
+        MCPToolCallError("tool failed"),
+    ],
+)
+def test_ordinary_failures_are_not_connection_loss(error: BaseException) -> None:
+    assert not is_connection_loss(error)
+
+
+def test_connection_loss_is_found_through_chains_and_groups() -> None:
+    wrapper = RuntimeError("sdk wrapper")
+    wrapper.__cause__ = httpx2.ReadError("socket closed")
+    assert is_connection_loss(wrapper)
+
+    handling = RuntimeError("raised while handling")
+    handling.__context__ = ConnectionResetError("peer reset")
+    assert is_connection_loss(handling)
+
+    group = BaseExceptionGroup(
+        "task group",
+        [ValueError("unrelated"), ExceptionGroup("inner", [BrokenPipeError("pipe")])],
+    )
+    assert is_connection_loss(group)
+    assert not is_connection_loss(ExceptionGroup("clean", [ValueError("still ordinary")]))
+
+
+def test_official_sdk_connection_closed_is_classified_but_timeout_is_not() -> None:
+    """The SDK normalizes a dead dispatcher to MCPError(CONNECTION_CLOSED),
+    so recovery cannot depend only on its lower-level AnyIO cause."""
+    assert is_connection_loss(SDKMCPError(code=CONNECTION_CLOSED, message="Connection closed"))
+    assert not is_connection_loss(SDKMCPError(code=REQUEST_TIMEOUT, message="Request timed out"))
+
+    wrapped = RuntimeError("SDK wrapper")
+    wrapped.__cause__ = SDKMCPError(code=CONNECTION_CLOSED, message="Connection closed")
+    assert is_connection_loss(wrapped)
+
+
+@pytest.mark.asyncio
+async def test_executor_tags_connection_loss_without_changing_the_error() -> None:
+    source = MCPSource.http("github", "https://mcp.example.com")
+
+    class _DyingClient:
+        error: Exception = httpx2.ReadError("socket closed")
+
+        async def call_tool(self, name: str, arguments: dict[str, Any], **kwargs: Any) -> Any:
+            raise type(self).error
+
+    adapter = MCPClientAdapter(source)
+    adapter._client = _DyingClient()  # type: ignore[assignment]
+    executor = create_mcp_executor(
+        adapter,
+        namespace="github",
+        mcp_tool_name="write",
+        max_result_bytes=10_000,
+    )
+
+    with pytest.raises(MCPToolCallError) as lost:
+        await executor()
+    assert lost.value.connection_lost is True
+    assert str(lost.value) == "MCP tool 'github__write' call failed: socket closed"
+    assert lost.value.__cause__ is None and lost.value.__context__ is None
+
+    _DyingClient.error = RuntimeError("tool exploded")
+    with pytest.raises(MCPToolCallError) as ordinary:
+        await executor()
+    assert ordinary.value.connection_lost is False

--- a/packages/python/tests/unit/test_mcp_public_api.py
+++ b/packages/python/tests/unit/test_mcp_public_api.py
@@ -1,0 +1,243 @@
+"""Contract tests for the public ``dendrux.mcp`` API surface.
+
+The exact ``__all__`` list below is the compatibility contract: adding a
+name is a deliberate API decision and removing one is a breaking change.
+These tests also pin the properties that make the surface production-safe:
+internals stay private, every public annotation resolves at runtime, and
+imports and construction perform no connection or credential work.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import subprocess
+import sys
+import textwrap
+import types
+from typing import TYPE_CHECKING, get_type_hints
+
+import dendrux.mcp as mcp_pkg
+from dendrux.mcp import (
+    MCPConnectionStatus,
+    MCPCredentialProvider,
+    MCPRuntime,
+    MCPRuntimeObserver,
+    MCPRuntimeSnapshot,
+    MCPRuntimeState,
+    MCPSource,
+)
+
+if TYPE_CHECKING:
+    import pytest
+
+EXPECTED_ALL = (
+    "MCPAuthenticationError",
+    "MCPBindingConflictError",
+    "MCPCallCapacityError",
+    "MCPCallCapacityRejected",
+    "MCPCapacityError",
+    "MCPCircuitClosed",
+    "MCPCircuitOpenError",
+    "MCPCircuitOpened",
+    "MCPCircuitProbing",
+    "MCPConnection",
+    "MCPConnectionAborted",
+    "MCPConnectionCapacityError",
+    "MCPConnectionCapacityRejected",
+    "MCPConnectionClosed",
+    "MCPConnectionError",
+    "MCPConnectionEvent",
+    "MCPConnectionEvictingError",
+    "MCPConnectionFailed",
+    "MCPConnectionLostError",
+    "MCPConnectionOpened",
+    "MCPConnectionOpening",
+    "MCPConnectionSnapshot",
+    "MCPConnectionStateError",
+    "MCPConnectionStatus",
+    "MCPCredentialError",
+    "MCPCredentialProvider",
+    "MCPError",
+    "MCPEvictionCompleted",
+    "MCPEvictionMode",
+    "MCPEvictionStarted",
+    "MCPFailureMode",
+    "MCPHost",
+    "MCPOpenCircuitSnapshot",
+    "MCPOutcomeUnknownError",
+    "MCPPhysicalConnectionEvent",
+    "MCPResultTooLargeError",
+    "MCPRuntime",
+    "MCPRuntimeClosedError",
+    "MCPRuntimeEvent",
+    "MCPRuntimeObserver",
+    "MCPRuntimeShutdownCompleted",
+    "MCPRuntimeShutdownStarted",
+    "MCPRuntimeSnapshot",
+    "MCPRuntimeState",
+    "MCPServer",
+    "MCPSource",
+    "MCPStaleConnectionError",
+    "MCPToolCallCancelled",
+    "MCPToolCallCompleted",
+    "MCPToolCallError",
+    "MCPToolCallFailed",
+    "MCPToolCallOutcomeUnknown",
+    "MCPToolCallStarted",
+    "MCPToolPolicy",
+    "MCPToolView",
+)
+
+
+class TestPublicSurfaceContract:
+    def test_all_matches_the_contract_exactly(self) -> None:
+        assert tuple(mcp_pkg.__all__) == EXPECTED_ALL
+
+    def test_contract_is_sorted(self) -> None:
+        assert list(EXPECTED_ALL) == sorted(EXPECTED_ALL)
+
+    def test_every_exported_name_resolves_to_package_code(self) -> None:
+        for name in EXPECTED_ALL:
+            obj = getattr(mcp_pkg, name)
+            assert obj is not None, name
+            if isinstance(obj, type):
+                assert obj.__module__.startswith("dendrux.mcp"), name
+
+    def test_star_import_exposes_exactly_the_contract(self) -> None:
+        namespace: dict[str, object] = {}
+        exec("from dendrux.mcp import *", namespace)  # noqa: S102
+        imported = {name for name in namespace if not name.startswith("__")}
+        assert imported == set(EXPECTED_ALL)
+
+    def test_no_unlisted_public_attributes(self) -> None:
+        # Submodules and the SDK import are module objects; everything else
+        # reachable without an underscore must be part of the contract.
+        public = {
+            name
+            for name, value in vars(mcp_pkg).items()
+            if not name.startswith("_") and not isinstance(value, types.ModuleType)
+        }
+        assert public == set(EXPECTED_ALL)
+
+    def test_internal_machinery_stays_private(self) -> None:
+        for name in (
+            "MCPClientAdapter",
+            "_ConnectionEntry",
+            "_CallPermit",
+            "_CallWaiter",
+            "_Admission",
+            "_CircuitState",
+            "_Registration",
+            "_ViewToolSource",
+            "build_mcp_tool_defs",
+            "create_mcp_executor",
+            "redact_source_text",
+            "redact_source_value",
+        ):
+            assert not hasattr(mcp_pkg, name), name
+
+
+class TestPublicAnnotationsResolve:
+    def test_every_exported_class_and_public_method_resolves_type_hints(self) -> None:
+        for name in EXPECTED_ALL:
+            obj = getattr(mcp_pkg, name)
+            if isinstance(obj, type):
+                get_type_hints(obj)
+                for member_name, descriptor in vars(obj).items():
+                    if member_name.startswith("_") and member_name != "__init__":
+                        continue
+                    if isinstance(descriptor, (classmethod, staticmethod)):
+                        target = descriptor.__func__
+                    elif isinstance(descriptor, property):
+                        target = descriptor.fget
+                    elif inspect.isfunction(descriptor):
+                        target = descriptor
+                    else:
+                        target = None
+                    if target is not None:
+                        get_type_hints(target)
+
+    def test_protocol_methods_resolve_to_public_types(self) -> None:
+        observer_hints = get_type_hints(MCPRuntimeObserver.on_event)
+        assert observer_hints["event"] is mcp_pkg.MCPRuntimeEvent
+        provider_hints = get_type_hints(MCPCredentialProvider.get_auth)
+        assert "return" in provider_hints
+
+    def test_snapshot_hints_name_public_types(self) -> None:
+        hints = get_type_hints(MCPRuntimeSnapshot)
+        assert hints["state"] is MCPRuntimeState
+        connection_hints = get_type_hints(mcp_pkg.MCPConnectionSnapshot)
+        assert connection_hints["status"] is MCPConnectionStatus
+
+
+class TestConstructionPurity:
+    def test_import_and_inert_construction_perform_no_external_io(self) -> None:
+        probe = textwrap.dedent(
+            """
+            import sys
+
+            def reject_external_io(event, args):
+                if event in {"socket.__new__", "socket.connect", "subprocess.Popen"}:
+                    raise AssertionError(f"external I/O during MCP import: {event}")
+
+            sys.addaudithook(reject_external_io)
+
+            from dendrux.mcp import MCPRuntime, MCPSource
+
+            runtime = MCPRuntime()
+            connection = runtime.bind(
+                connection_key="github-1",
+                source=MCPSource.http("github", "https://mcp.example.com"),
+            )
+            view = connection.tools(allowed_tools=["read_file"])
+            snapshot = runtime.snapshot()
+            assert view.namespace == "github"
+            assert snapshot.connections == ()
+            """
+        )
+
+        completed = subprocess.run(
+            [sys.executable, "-c", probe],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=10,
+        )
+
+        assert completed.returncode == 0, completed.stderr
+
+    def test_bind_and_views_perform_no_connection_or_credential_work(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class ExplodingAdapter:
+            def __init__(self, source: MCPSource) -> None:
+                raise AssertionError("adapter constructed without a lease")
+
+        monkeypatch.setattr("dendrux.mcp._runtime.MCPClientAdapter", ExplodingAdapter)
+
+        class Provider:
+            calls = 0
+
+            async def get_auth(self) -> dict[str, str]:
+                type(self).calls += 1
+                return {"Authorization": "Bearer never-used"}
+
+        # Through snapshot, construction remains synchronous and loop-free.
+        # asyncio.run below exists only to exercise inert-runtime cleanup.
+        runtime = MCPRuntime()
+        connection = runtime.bind(
+            connection_key="github-1",
+            tenant_key="tenant-a",
+            source=MCPSource.http("github", "https://mcp.example.com"),
+            credentials=Provider(),
+        )
+        view = connection.tools(allowed_tools=["read_file"])
+        snapshot = runtime.snapshot()
+
+        assert snapshot.state is MCPRuntimeState.OPEN
+        assert snapshot.connections == ()
+        assert snapshot.in_flight_calls == 0
+        assert Provider.calls == 0
+        assert view.namespace == "github"
+        asyncio.run(runtime.close())

--- a/packages/python/tests/unit/test_mcp_runtime.py
+++ b/packages/python/tests/unit/test_mcp_runtime.py
@@ -12,8 +12,11 @@ from mcp.types import CallToolResult, TextContent, Tool, ToolAnnotations
 
 from dendrux.agent import Agent
 from dendrux.mcp import (
+    MCPConnectionClosed,
     MCPHost,
     MCPResultTooLargeError,
+    MCPRuntime,
+    MCPRuntimeEvent,
     MCPServer,
     MCPSource,
     MCPToolCallError,
@@ -275,6 +278,41 @@ class TestMCPToolAdaptation:
             assert await executor(message="hello through MCP") == {"result": "hello through MCP"}
         finally:
             await server.close()
+
+    @pytest.mark.asyncio
+    async def test_managed_real_sdk_stdio_closes_in_its_owner_task(self, caplog: Any) -> None:
+        fixture = Path(__file__).parents[1] / "fixtures" / "mcp_echo_server.py"
+        events: list[MCPRuntimeEvent] = []
+
+        class Observer:
+            def on_event(self, event: MCPRuntimeEvent) -> None:
+                events.append(event)
+
+        runtime = MCPRuntime(observer=Observer(), shutdown_timeout=1.0)
+        connection = runtime.bind(
+            connection_key="echo-1",
+            source=MCPSource.stdio(
+                "echo",
+                [sys.executable, str(fixture)],
+                connect_timeout=10.0,
+                call_timeout=10.0,
+            ),
+        )
+        agent = Agent(prompt="test", tool_sources=[connection.tools()])
+
+        try:
+            lookups = await agent.get_tool_lookups()
+            assert await lookups.fn["echo__echo"](message="managed MCP") == {
+                "result": "managed MCP"
+            }
+        finally:
+            await agent.close()
+            await runtime.close()
+
+        closed = [event for event in events if isinstance(event, MCPConnectionClosed)]
+        assert len(closed) == 1
+        assert closed[0].clean is True
+        assert "cancel scope" not in caplog.text.lower()
 
     @pytest.mark.asyncio
     async def test_discovery_exposes_tools_and_sets_safe_parallelism(self) -> None:

--- a/packages/python/tests/unit/test_mcp_runtime_live.py
+++ b/packages/python/tests/unit/test_mcp_runtime_live.py
@@ -9,9 +9,10 @@ on Agent.close(), and drain-based runtime shutdown.
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 from collections import deque
 from collections.abc import Mapping
-from typing import Any, ClassVar
+from typing import Any, ClassVar, get_type_hints
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -33,6 +34,31 @@ from dendrux.mcp._errors import (
     MCPRuntimeClosedError,
     MCPStaleConnectionError,
     MCPToolCallError,
+)
+from dendrux.mcp._observability import (
+    MCPCallCapacityRejected,
+    MCPCircuitClosed,
+    MCPCircuitOpened,
+    MCPCircuitProbing,
+    MCPConnectionAborted,
+    MCPConnectionCapacityRejected,
+    MCPConnectionClosed,
+    MCPConnectionFailed,
+    MCPConnectionOpened,
+    MCPConnectionOpening,
+    MCPConnectionSnapshot,
+    MCPConnectionStatus,
+    MCPEvictionCompleted,
+    MCPEvictionStarted,
+    MCPRuntimeEvent,
+    MCPRuntimeShutdownCompleted,
+    MCPRuntimeShutdownStarted,
+    MCPRuntimeSnapshot,
+    MCPToolCallCancelled,
+    MCPToolCallCompleted,
+    MCPToolCallFailed,
+    MCPToolCallOutcomeUnknown,
+    MCPToolCallStarted,
 )
 from dendrux.mcp._runtime import (
     MCPConnection,
@@ -5163,3 +5189,823 @@ class TestCircuitBreaker:
             MCPRuntime(circuit_reset_timeout=0)
         with pytest.raises(ValueError, match="circuit_reset_timeout"):
             MCPRuntime(circuit_reset_timeout=-1.0)
+
+
+class _RecordingObserver:
+    """Collects every runtime event; optionally raises to prove isolation."""
+
+    def __init__(self, error: Exception | None = None) -> None:
+        self.events: list[MCPRuntimeEvent] = []
+        self.error = error
+
+    def on_event(self, event: MCPRuntimeEvent) -> None:
+        self.events.append(event)
+        if self.error is not None:
+            raise self.error
+
+    def of(self, event_type: type) -> list[Any]:
+        return [event for event in self.events if isinstance(event, event_type)]
+
+    def kinds(self) -> list[type]:
+        return [type(event) for event in self.events]
+
+
+def _event_text(events: list[MCPRuntimeEvent]) -> str:
+    """Every field value an exporter would read off the events."""
+    return "\n".join(str(value) for event in events for value in dataclasses.asdict(event).values())
+
+
+class TestRuntimeSnapshot:
+    """runtime.snapshot() is an immutable point-in-time operational view.
+
+    The runtime-level equivalent of connection-pool metrics: which
+    connections exist and in what state, how many calls are running or
+    queueing, and which circuits are open. No persistence, no I/O.
+    """
+
+    def test_an_unused_runtime_reports_an_empty_snapshot(self) -> None:
+        runtime = MCPRuntime()
+
+        snapshot = runtime.snapshot()
+
+        assert snapshot.state is MCPRuntimeState.OPEN
+        assert snapshot.connections == ()
+        assert snapshot.in_flight_calls == 0
+        assert snapshot.connection_waiters == 0
+        assert snapshot.call_waiters == 0
+        assert snapshot.open_circuits == ()
+
+    @pytest.mark.asyncio
+    async def test_a_live_connection_reports_status_and_leases(self) -> None:
+        async with MCPRuntime(shutdown_timeout=0.05) as runtime:
+            connection = _bind(runtime, tenant_key="tenant-a")
+            agent = Agent(prompt="test", tool_sources=[connection.tools()])
+            await agent.get_tool_lookups()
+
+            snapshot = runtime.snapshot()
+            assert len(snapshot.connections) == 1
+            live = snapshot.connections[0]
+            assert live.tenant_key == "tenant-a"
+            assert live.connection_key == "github-1"
+            assert live.source_name == "github"
+            assert live.status is MCPConnectionStatus.ACTIVE
+            assert live.status == "active"
+            assert live.leases == 1
+            assert live.active_calls == 0
+
+            await agent.close()
+            idle = runtime.snapshot().connections[0]
+            assert idle.status == "idle"
+            assert idle.leases == 0
+
+    @pytest.mark.asyncio
+    async def test_a_connecting_entry_is_reported_before_establishment(self) -> None:
+        gate = asyncio.Event()
+        _InstrumentedAdapter.connect_gate = gate
+        async with MCPRuntime(shutdown_timeout=0.05) as runtime:
+            connection = _bind(runtime)
+            agent = Agent(prompt="test", tool_sources=[connection.tools()])
+            acquisition = asyncio.create_task(agent.get_tool_lookups())
+            await _wait_until(lambda: runtime._entries != {})
+
+            connecting = runtime.snapshot().connections[0]
+            assert connecting.status == "connecting"
+            assert connecting.leases == 1
+
+            gate.set()
+            await acquisition
+            assert runtime.snapshot().connections[0].status == "active"
+            await agent.close()
+
+    @pytest.mark.asyncio
+    async def test_in_flight_and_queued_calls_are_counted(self) -> None:
+        _InstrumentedAdapter.call_gate = asyncio.Event()
+        async with MCPRuntime(
+            max_in_flight_calls=1, call_wait_timeout=5.0, shutdown_timeout=0.05
+        ) as runtime:
+            connection = _bind(runtime)
+            agent = Agent(prompt="test", tool_sources=[connection.tools()])
+            lookups = await agent.get_tool_lookups()
+            adapter = _InstrumentedAdapter.instances[0]
+
+            first = asyncio.create_task(lookups.fn["github__write"](value="first"))
+            second = asyncio.create_task(lookups.fn["github__read"](value="second"))
+            await _await_first_call(adapter)
+            await _wait_until(lambda: len(runtime._call_queue) == 1)
+
+            snapshot = runtime.snapshot()
+            assert snapshot.in_flight_calls == 1
+            assert snapshot.call_waiters == 1
+            assert snapshot.connections[0].active_calls == 1
+            assert snapshot.connections[0].status == "active"
+
+            _InstrumentedAdapter.call_gate.set()
+            await asyncio.gather(first, second)
+            await agent.close()
+
+    @pytest.mark.asyncio
+    async def test_callers_waiting_for_connection_capacity_are_counted(self) -> None:
+        async with MCPRuntime(
+            max_connections=1, connection_wait_timeout=5.0, shutdown_timeout=0.05
+        ) as runtime:
+            holder = _bind(runtime, tenant_key="tenant-a")
+            holding_agent = Agent(prompt="hold", tool_sources=[holder.tools()])
+            await holding_agent.get_tool_lookups()
+
+            waiting = _bind(runtime, tenant_key="tenant-b")
+            waiting_agent = Agent(prompt="wait", tool_sources=[waiting.tools()])
+            acquisition = asyncio.create_task(waiting_agent.get_tool_lookups())
+            await _wait_until(lambda: runtime._admissions != {})
+
+            assert runtime.snapshot().connection_waiters == 1
+
+            await holding_agent.close()  # frees the slot via pressure retirement
+            await acquisition
+            assert runtime.snapshot().connection_waiters == 0
+            await waiting_agent.close()
+
+    @pytest.mark.asyncio
+    async def test_open_circuits_are_listed_with_retry_after(self) -> None:
+        _InstrumentedAdapter.connect_error = ConnectionError("server down")
+        async with MCPRuntime(
+            circuit_failure_threshold=1, circuit_reset_timeout=30.0, shutdown_timeout=0.05
+        ) as runtime:
+            broken = _bind(runtime, tenant_key="tenant-a")
+            failing = Agent(prompt="fail", tool_sources=[broken.tools()])
+            with pytest.raises(ConnectionError):
+                await failing.get_tool_lookups()
+
+            _InstrumentedAdapter.connect_error = None
+            healthy = _bind(runtime, tenant_key="tenant-b")
+            healthy_agent = Agent(prompt="ok", tool_sources=[healthy.tools()])
+            await healthy_agent.get_tool_lookups()
+
+            snapshot = runtime.snapshot()
+            assert len(snapshot.open_circuits) == 1
+            circuit = snapshot.open_circuits[0]
+            assert circuit.tenant_key == "tenant-a"
+            assert circuit.connection_key == "github-1"
+            assert circuit.source_name == "github"
+            assert circuit.failure_count == 1
+            assert circuit.last_failure == "ConnectionError"
+            assert 0 < circuit.retry_after <= 30.0
+            await healthy_agent.close()
+
+    @pytest.mark.asyncio
+    async def test_snapshots_are_immutable(self) -> None:
+        _InstrumentedAdapter.connect_error = ConnectionError("server down")
+        async with MCPRuntime(
+            circuit_failure_threshold=1, circuit_reset_timeout=30.0, shutdown_timeout=0.05
+        ) as runtime:
+            broken = _bind(runtime, tenant_key="tenant-a")
+            failing = Agent(prompt="fail", tool_sources=[broken.tools()])
+            with pytest.raises(ConnectionError):
+                await failing.get_tool_lookups()
+            _InstrumentedAdapter.connect_error = None
+            live = _bind(runtime, tenant_key="tenant-b")
+            agent = Agent(prompt="ok", tool_sources=[live.tools()])
+            await agent.get_tool_lookups()
+
+            snapshot = runtime.snapshot()
+            with pytest.raises(dataclasses.FrozenInstanceError):
+                snapshot.in_flight_calls = 99  # type: ignore[misc]
+            with pytest.raises(dataclasses.FrozenInstanceError):
+                snapshot.connections[0].leases = 99  # type: ignore[misc]
+            with pytest.raises(dataclasses.FrozenInstanceError):
+                snapshot.open_circuits[0].retry_after = 0.0  # type: ignore[misc]
+            await agent.close()
+
+
+class TestRuntimeObserver:
+    """Optional lifecycle events for connecting external monitoring.
+
+    Typed, immutable, value-free events delivered synchronously outside
+    every runtime lock. Observer failures are swallowed and logged without
+    detail: telemetry can never break MCP work.
+    """
+
+    @pytest.mark.asyncio
+    async def test_connection_lifecycle_events_are_emitted(self) -> None:
+        observer = _RecordingObserver()
+        async with MCPRuntime(
+            observer=observer, idle_timeout=0.0, shutdown_timeout=0.05
+        ) as runtime:
+            connection = _bind(runtime, tenant_key="tenant-a")
+            agent = Agent(prompt="test", tool_sources=[connection.tools()])
+            await agent.get_tool_lookups()
+            await agent.close()
+            await _wait_until(lambda: runtime._entries == {})
+
+        kinds = observer.kinds()
+        assert kinds.index(MCPConnectionOpening) < kinds.index(MCPConnectionOpened)
+        assert kinds.index(MCPConnectionOpened) < kinds.index(MCPConnectionClosed)
+        opened = observer.of(MCPConnectionOpened)[0]
+        assert opened.tenant_key == "tenant-a"
+        assert opened.connection_key == "github-1"
+        assert opened.source_name == "github"
+        assert opened.tool_count == 2
+        assert observer.of(MCPConnectionClosed)[0].reason == "idle"
+
+    @pytest.mark.asyncio
+    async def test_connection_failures_emit_value_free_causes(self) -> None:
+        _InstrumentedAdapter.connect_error = ConnectionError("secret detail in transport text")
+        observer = _RecordingObserver()
+        async with MCPRuntime(observer=observer, shutdown_timeout=0.05) as runtime:
+            connection = _bind(runtime)
+            agent = Agent(prompt="test", tool_sources=[connection.tools()])
+            with pytest.raises(ConnectionError):
+                await agent.get_tool_lookups()
+
+        failed = observer.of(MCPConnectionFailed)[0]
+        assert failed.cause == "ConnectionError"
+        assert "secret detail" not in _event_text(observer.events)
+
+    @pytest.mark.asyncio
+    async def test_circuit_lifecycle_events_are_emitted(self) -> None:
+        _InstrumentedAdapter.connect_error = ConnectionError("server down")
+        observer = _RecordingObserver()
+        async with MCPRuntime(
+            observer=observer,
+            circuit_failure_threshold=1,
+            circuit_reset_timeout=0.05,
+            shutdown_timeout=0.05,
+        ) as runtime:
+            connection = _bind(runtime)
+            failing = Agent(prompt="fail", tool_sources=[connection.tools()])
+            with pytest.raises(ConnectionError):
+                await failing.get_tool_lookups()
+
+            opened = observer.of(MCPCircuitOpened)[0]
+            assert opened.failure_count == 1
+            assert opened.last_failure == "ConnectionError"
+            assert opened.reset_timeout == 0.05
+
+            await asyncio.sleep(0.1)
+            _InstrumentedAdapter.connect_error = None
+            probe = Agent(prompt="probe", tool_sources=[connection.tools()])
+            await probe.get_tool_lookups()
+
+            kinds = observer.kinds()
+            assert kinds.index(MCPCircuitOpened) < kinds.index(MCPCircuitProbing)
+            assert kinds.index(MCPCircuitProbing) < kinds.index(MCPCircuitClosed)
+            assert len(observer.of(MCPCircuitClosed)) == 1
+            await probe.close()
+
+    @pytest.mark.asyncio
+    async def test_eviction_events_are_emitted(self) -> None:
+        observer = _RecordingObserver()
+        async with MCPRuntime(observer=observer, shutdown_timeout=0.05) as runtime:
+            connection = _bind(runtime)
+            agent = Agent(prompt="test", tool_sources=[connection.tools()])
+            await agent.get_tool_lookups()
+            await agent.close()
+
+            await runtime.evict(connection_key="github-1")
+
+            started = observer.of(MCPEvictionStarted)[0]
+            assert started.mode == "drain"
+            assert started.connection_key == "github-1"
+            assert observer.of(MCPEvictionCompleted)[0].forced is False
+            assert observer.of(MCPConnectionClosed)[0].reason == "evicted"
+            kinds = observer.kinds()
+            assert kinds.index(MCPEvictionStarted) < kinds.index(MCPConnectionClosed)
+            assert kinds.index(MCPConnectionClosed) < kinds.index(MCPEvictionCompleted)
+
+    @pytest.mark.asyncio
+    async def test_forced_eviction_reports_forced_completion(self) -> None:
+        _InstrumentedAdapter.call_gate = asyncio.Event()
+        observer = _RecordingObserver()
+        async with MCPRuntime(observer=observer, shutdown_timeout=0.05) as runtime:
+            connection = _bind(runtime)
+            agent = Agent(prompt="test", tool_sources=[connection.tools()])
+            lookups = await agent.get_tool_lookups()
+            call = asyncio.create_task(lookups.fn["github__write"](value="running"))
+            await _await_first_call(_InstrumentedAdapter.instances[0])
+
+            await runtime.evict(connection_key="github-1", mode="force")
+
+            with pytest.raises(MCPOutcomeUnknownError):
+                await call
+            assert observer.of(MCPEvictionCompleted)[0].forced is True
+            unknown = observer.of(MCPToolCallOutcomeUnknown)[0]
+            assert unknown.tool == "github__write"
+            assert unknown.reason == "forced"
+            await agent.close()
+
+    @pytest.mark.asyncio
+    async def test_tool_call_events_are_emitted(self) -> None:
+        observer = _RecordingObserver()
+        async with MCPRuntime(observer=observer, shutdown_timeout=0.05) as runtime:
+            connection = _bind(runtime)
+            agent = Agent(prompt="test", tool_sources=[connection.tools()])
+            lookups = await agent.get_tool_lookups()
+
+            assert await lookups.fn["github__read"](value=1) == "read:ok"
+            started = observer.of(MCPToolCallStarted)[0]
+            assert started.tool == "github__read"
+            completed = observer.of(MCPToolCallCompleted)[0]
+            assert completed.tool == "github__read"
+            assert completed.duration >= 0.0
+
+            _InstrumentedAdapter.call_error = RuntimeError("boom with detail")
+            with pytest.raises(MCPToolCallError):
+                await lookups.fn["github__write"](value=2)
+            failed = observer.of(MCPToolCallFailed)[0]
+            assert failed.tool == "github__write"
+            assert failed.cause == "MCPToolCallError"
+            assert failed.duration >= 0.0
+            assert "boom with detail" not in _event_text(observer.events)
+            await agent.close()
+
+    @pytest.mark.asyncio
+    async def test_transport_loss_emits_outcome_unknown_and_broken_close(self) -> None:
+        _InstrumentedAdapter.call_error = ConnectionResetError("socket died")
+        observer = _RecordingObserver()
+        async with MCPRuntime(observer=observer, shutdown_timeout=0.05) as runtime:
+            connection = _bind(runtime)
+            agent = Agent(prompt="test", tool_sources=[connection.tools()])
+            lookups = await agent.get_tool_lookups()
+
+            with pytest.raises(MCPOutcomeUnknownError):
+                await lookups.fn["github__write"](value=1)
+            await _wait_until(lambda: runtime._entries == {})
+
+            unknown = observer.of(MCPToolCallOutcomeUnknown)[0]
+            assert unknown.tool == "github__write"
+            assert unknown.reason == "connection_lost"
+            assert observer.of(MCPConnectionClosed)[0].reason == "broken"
+            assert "socket died" not in _event_text(observer.events)
+            await agent.close()
+
+    @pytest.mark.asyncio
+    async def test_call_capacity_rejections_are_emitted(self) -> None:
+        _InstrumentedAdapter.call_gate = asyncio.Event()
+        observer = _RecordingObserver()
+        async with MCPRuntime(
+            observer=observer,
+            max_in_flight_calls=1,
+            call_wait_timeout=0.0,
+            shutdown_timeout=0.05,
+        ) as runtime:
+            connection = _bind(runtime)
+            agent = Agent(prompt="test", tool_sources=[connection.tools()])
+            lookups = await agent.get_tool_lookups()
+            running = asyncio.create_task(lookups.fn["github__write"](value="running"))
+            await _await_first_call(_InstrumentedAdapter.instances[0])
+
+            with pytest.raises(MCPCallCapacityError):
+                await lookups.fn["github__read"](value="shed")
+
+            rejected = observer.of(MCPCallCapacityRejected)[0]
+            assert rejected.tool == "github__read"
+            assert rejected.limit == 1
+            _InstrumentedAdapter.call_gate.set()
+            await running
+            await agent.close()
+
+    @pytest.mark.asyncio
+    async def test_connection_capacity_rejections_are_emitted(self) -> None:
+        observer = _RecordingObserver()
+        async with MCPRuntime(
+            observer=observer,
+            max_connections=1,
+            connection_wait_timeout=0.0,
+            shutdown_timeout=0.05,
+        ) as runtime:
+            holder = _bind(runtime, tenant_key="tenant-a")
+            holding_agent = Agent(prompt="hold", tool_sources=[holder.tools()])
+            await holding_agent.get_tool_lookups()
+
+            waiting = _bind(runtime, tenant_key="tenant-b")
+            waiting_agent = Agent(prompt="wait", tool_sources=[waiting.tools()])
+            with pytest.raises(MCPConnectionCapacityError):
+                await waiting_agent.get_tool_lookups()
+
+            rejected = observer.of(MCPConnectionCapacityRejected)[0]
+            assert rejected.tenant_key == "tenant-b"
+            assert rejected.limit == 1
+            await holding_agent.close()
+
+    @pytest.mark.asyncio
+    async def test_shutdown_events_are_emitted(self) -> None:
+        observer = _RecordingObserver()
+        runtime = MCPRuntime(observer=observer, shutdown_timeout=0.05)
+        connection = _bind(runtime)
+        agent = Agent(prompt="test", tool_sources=[connection.tools()])
+        await agent.get_tool_lookups()
+        await agent.close()
+
+        await runtime.close()
+
+        assert observer.of(MCPRuntimeShutdownStarted) != []
+        completed = observer.of(MCPRuntimeShutdownCompleted)[0]
+        assert completed.forced is False
+        assert observer.events[-1] is completed
+        assert observer.of(MCPConnectionClosed)[0].reason == "shutdown"
+
+    @pytest.mark.asyncio
+    async def test_observer_failures_never_break_mcp_work(self, caplog: Any) -> None:
+        observer = _RecordingObserver(error=RuntimeError("observer secret text"))
+        with caplog.at_level("WARNING"):
+            async with MCPRuntime(
+                observer=observer, idle_timeout=0.0, shutdown_timeout=0.05
+            ) as runtime:
+                connection = _bind(runtime)
+                agent = Agent(prompt="test", tool_sources=[connection.tools()])
+                lookups = await agent.get_tool_lookups()
+                assert await lookups.fn["github__read"](value=1) == "read:ok"
+                await agent.close()
+                await _wait_until(lambda: runtime._entries == {})
+
+        assert len(observer.events) >= 4  # every event was still delivered
+        assert "observer secret text" not in caplog.text
+        assert any("observer" in record.message for record in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_callbacks_run_outside_the_runtime_lock(self) -> None:
+        class _LockProbingObserver:
+            """Records a violation if an event arrives under the runtime lock."""
+
+            def __init__(self) -> None:
+                self.runtime: MCPRuntime | None = None
+                self.violations: list[str] = []
+                self.snapshots = 0
+
+            def on_event(self, event: MCPRuntimeEvent) -> None:
+                runtime = self.runtime
+                assert runtime is not None
+                if runtime._lock.acquire(blocking=False):
+                    runtime._lock.release()
+                else:
+                    self.violations.append(type(event).__name__)
+                    return
+                runtime.snapshot()  # re-entrancy: snapshot() from a callback
+                self.snapshots += 1
+
+        observer = _LockProbingObserver()
+        runtime = MCPRuntime(
+            observer=observer,
+            circuit_failure_threshold=1,
+            circuit_reset_timeout=0.05,
+            shutdown_timeout=0.05,
+        )
+        observer.runtime = runtime
+        connection = _bind(runtime)
+
+        _InstrumentedAdapter.connect_error = ConnectionError("server down")
+        failing = Agent(prompt="fail", tool_sources=[connection.tools()])
+        with pytest.raises(ConnectionError):
+            await failing.get_tool_lookups()
+        await asyncio.sleep(0.1)
+
+        _InstrumentedAdapter.connect_error = None
+        agent = Agent(prompt="probe", tool_sources=[connection.tools()])
+        lookups = await agent.get_tool_lookups()
+        assert await lookups.fn["github__read"](value=1) == "read:ok"
+        await agent.close()
+        await runtime.evict(connection_key="github-1")
+        await runtime.close()
+
+        assert observer.violations == []
+        assert observer.snapshots >= 8
+
+    @pytest.mark.asyncio
+    async def test_events_never_carry_credentials(self) -> None:
+        provider = _Credentials()  # resolves "Bearer must-not-leak"
+        observer = _RecordingObserver()
+        async with MCPRuntime(observer=observer, shutdown_timeout=0.05) as runtime:
+            connection = _bind(runtime, credentials=provider)
+            agent = Agent(prompt="test", tool_sources=[connection.tools()])
+            lookups = await agent.get_tool_lookups()
+
+            _InstrumentedAdapter.call_error = ConnectionResetError(
+                "peer reset during Authorization: Bearer must-not-leak"
+            )
+            with pytest.raises(MCPOutcomeUnknownError):
+                await lookups.fn["github__write"](value=1)
+            await _wait_until(lambda: runtime._entries == {})
+            await agent.close()
+
+        assert observer.events != []
+        assert "must-not-leak" not in _event_text(observer.events)
+
+    def test_the_observer_is_validated_at_construction(self) -> None:
+        with pytest.raises(ValueError, match="observer"):
+            MCPRuntime(observer=object())  # type: ignore[arg-type]
+
+        assert MCPRuntime(observer=None) is not None
+        assert MCPRuntime(observer=_RecordingObserver()) is not None
+
+
+class TestObservabilityHardening:
+    """Review hardening for the observability slice.
+
+    Exact start/terminal event pairing, physical-instance correlation
+    across reconnects, honest close and gauge semantics, Agent-visible
+    canonical tool names, runtime-resolvable annotations, and strict
+    observer validation.
+    """
+
+    @pytest.mark.asyncio
+    async def test_application_cancellation_emits_a_terminal_call_event(self) -> None:
+        _InstrumentedAdapter.call_gate = asyncio.Event()
+        observer = _RecordingObserver()
+        async with MCPRuntime(observer=observer, shutdown_timeout=0.05) as runtime:
+            connection = _bind(runtime)
+            agent = Agent(prompt="test", tool_sources=[connection.tools()])
+            lookups = await agent.get_tool_lookups()
+            call = asyncio.create_task(lookups.fn["github__write"](value=1))
+            await _await_first_call(_InstrumentedAdapter.instances[0])
+
+            call.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await call
+
+            cancelled = observer.of(MCPToolCallCancelled)[0]
+            assert cancelled.tool == "github__write"
+            assert cancelled.duration >= 0.0
+            # Exactly one terminal event per started call.
+            terminals = (
+                observer.of(MCPToolCallCompleted)
+                + observer.of(MCPToolCallFailed)
+                + observer.of(MCPToolCallOutcomeUnknown)
+                + observer.of(MCPToolCallCancelled)
+            )
+            assert len(observer.of(MCPToolCallStarted)) == len(terminals) == 1
+            await agent.close()
+
+    @pytest.mark.asyncio
+    async def test_cancelled_establishment_emits_a_terminal_connection_event(self) -> None:
+        _InstrumentedAdapter.connect_gate = asyncio.Event()
+        observer = _RecordingObserver()
+        runtime = MCPRuntime(observer=observer, shutdown_timeout=0.05)
+        connection = _bind(runtime)
+        agent = Agent(prompt="test", tool_sources=[connection.tools()])
+        acquisition = asyncio.create_task(agent.get_tool_lookups())
+        await _wait_until(lambda: runtime._entries != {})
+
+        await runtime.close()
+        await asyncio.gather(acquisition, return_exceptions=True)
+
+        assert len(observer.of(MCPConnectionOpening)) == 1
+        aborted = observer.of(MCPConnectionAborted)
+        assert len(aborted) == 1
+        assert observer.of(MCPConnectionOpened) == []
+        assert observer.of(MCPConnectionFailed) == []
+        opening = observer.of(MCPConnectionOpening)[0]
+        assert aborted[0].instance_id == opening.instance_id
+
+    @pytest.mark.asyncio
+    async def test_events_carry_the_physical_connection_instance(self) -> None:
+        observer = _RecordingObserver()
+        async with MCPRuntime(
+            observer=observer, idle_timeout=0.0, shutdown_timeout=0.05
+        ) as runtime:
+            connection = _bind(runtime)
+
+            first = Agent(prompt="first", tool_sources=[connection.tools()])
+            first_tools = await first.get_tool_lookups()
+            await first_tools.fn["github__read"](value=1)
+            await first.close()
+            await _wait_until(lambda: runtime._entries == {})
+
+            second = Agent(prompt="second", tool_sources=[connection.tools()])
+            second_tools = await second.get_tool_lookups()
+            await second_tools.fn["github__read"](value=2)
+
+            opened = observer.of(MCPConnectionOpened)
+            assert len(opened) == 2
+            assert opened[0].instance_id < opened[1].instance_id
+
+            closed = observer.of(MCPConnectionClosed)
+            assert closed[0].instance_id == opened[0].instance_id
+            assert closed[0].clean is True
+
+            started = observer.of(MCPToolCallStarted)
+            assert started[0].instance_id == opened[0].instance_id
+            assert started[1].instance_id == opened[1].instance_id
+
+            live = runtime.snapshot().connections[0]
+            assert live.instance_id == opened[1].instance_id
+            await second.close()
+
+    @pytest.mark.asyncio
+    async def test_unclean_transport_close_is_reported(self) -> None:
+        _InstrumentedAdapter.close_error = RuntimeError("close failed with detail")
+        observer = _RecordingObserver()
+        async with MCPRuntime(
+            observer=observer, idle_timeout=0.0, shutdown_timeout=0.05
+        ) as runtime:
+            connection = _bind(runtime)
+            agent = Agent(prompt="test", tool_sources=[connection.tools()])
+            await agent.get_tool_lookups()
+            await agent.close()
+            await _wait_until(lambda: runtime._entries == {})
+
+            closed = observer.of(MCPConnectionClosed)[0]
+            assert closed.reason == "idle"
+            assert closed.clean is False
+            assert "close failed" not in _event_text(observer.events)
+
+    @pytest.mark.asyncio
+    async def test_tool_call_events_use_agent_visible_names(self) -> None:
+        _InstrumentedAdapter.tools = [_tool("read.file", read_only=True)]
+        observer = _RecordingObserver()
+        async with MCPRuntime(observer=observer, shutdown_timeout=0.05) as runtime:
+            connection = _bind(runtime)
+            agent = Agent(prompt="test", tool_sources=[connection.tools()])
+            lookups = await agent.get_tool_lookups()
+
+            assert await lookups.fn["github__read_file"](value=1) == "read.file:ok"
+
+            assert observer.of(MCPToolCallStarted)[0].tool == "github__read_file"
+            assert observer.of(MCPToolCallCompleted)[0].tool == "github__read_file"
+            await agent.close()
+
+    @pytest.mark.asyncio
+    async def test_detached_calls_are_tracked_until_the_transport_exits(self) -> None:
+        _InstrumentedAdapter.call_gate = asyncio.Event()
+        _InstrumentedAdapter.suppress_call_cancel = True
+        observer = _RecordingObserver()
+        async with MCPRuntime(observer=observer, shutdown_timeout=0.05) as runtime:
+            connection = _bind(runtime)
+            agent = Agent(prompt="test", tool_sources=[connection.tools()])
+            lookups = await agent.get_tool_lookups()
+            call = asyncio.create_task(lookups.fn["github__write"](value="hostile"))
+            await _await_first_call(_InstrumentedAdapter.instances[0])
+
+            await runtime.evict(connection_key="github-1", mode="force")
+
+            try:
+                # The permit was reclaimed but the transport operation lives on.
+                snapshot = runtime.snapshot()
+                assert snapshot.in_flight_calls == 0
+                assert snapshot.detached_calls == 1
+            finally:
+                # Always free the hostile call, or a failing assertion would
+                # leave it swallowing cancellation and hang pytest teardown.
+                _InstrumentedAdapter.call_gate.set()
+            with pytest.raises(MCPOutcomeUnknownError):
+                await call
+            assert runtime.snapshot().detached_calls == 0
+            await agent.close()
+
+    def test_snapshot_type_hints_resolve_at_runtime(self) -> None:
+        hints = get_type_hints(MCPRuntimeSnapshot)
+        assert hints["state"] is MCPRuntimeState
+        assert get_type_hints(MCPConnectionSnapshot)["status"] is MCPConnectionStatus
+        assert get_type_hints(MCPToolCallCompleted)["duration"] is float
+
+    def test_unusable_observers_are_rejected(self) -> None:
+        class _NotCallable:
+            on_event = 1
+
+        class _AsyncObserver:
+            async def on_event(self, event: MCPRuntimeEvent) -> None:
+                return None
+
+        class _AsyncCallback:
+            async def __call__(self, event: MCPRuntimeEvent) -> None:
+                return None
+
+        class _WrappedAsyncObserver:
+            on_event = _AsyncCallback()
+
+        with pytest.raises(ValueError, match="observer"):
+            MCPRuntime(observer=_NotCallable())  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="synchronous"):
+            MCPRuntime(observer=_AsyncObserver())
+        with pytest.raises(ValueError, match="synchronous"):
+            MCPRuntime(observer=_WrappedAsyncObserver())
+
+    @pytest.mark.asyncio
+    async def test_observer_base_exceptions_never_break_mcp_work(self) -> None:
+        class _CancellingObserver:
+            def on_event(self, event: MCPRuntimeEvent) -> None:
+                raise asyncio.CancelledError
+
+        async with MCPRuntime(observer=_CancellingObserver(), shutdown_timeout=0.05) as runtime:
+            connection = _bind(runtime)
+            agent = Agent(prompt="test", tool_sources=[connection.tools()])
+            lookups = await agent.get_tool_lookups()
+
+            assert await lookups.fn["github__read"](value=1) == "read:ok"
+            await agent.close()
+
+        assert runtime.snapshot().connections == ()
+        assert runtime.snapshot().in_flight_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_observer_returning_an_awaitable_is_safely_rejected(self) -> None:
+        class _ReturningAwaitableObserver:
+            def __init__(self) -> None:
+                self.returned: list[Any] = []
+
+            async def _handle(self, event: MCPRuntimeEvent) -> None:
+                return None
+
+            def on_event(self, event: MCPRuntimeEvent) -> Any:
+                result = self._handle(event)
+                self.returned.append(result)
+                return result
+
+        observer = _ReturningAwaitableObserver()
+        async with MCPRuntime(observer=observer, shutdown_timeout=0.05) as runtime:
+            connection = _bind(runtime)
+            agent = Agent(prompt="test", tool_sources=[connection.tools()])
+            lookups = await agent.get_tool_lookups()
+
+            assert await lookups.fn["github__read"](value=1) == "read:ok"
+            await agent.close()
+
+        assert observer.returned
+        assert all(result.cr_frame is None for result in observer.returned)
+
+    @pytest.mark.asyncio
+    async def test_resistant_establishment_is_terminal_before_shutdown_completes(self) -> None:
+        _InstrumentedAdapter.connect_gate = asyncio.Event()
+        _InstrumentedAdapter.suppress_cancel = True
+        observer = _RecordingObserver()
+        runtime = MCPRuntime(observer=observer, shutdown_timeout=0.01)
+        agent = Agent(prompt="test", tool_sources=[_bind(runtime).tools()])
+        acquisition = asyncio.create_task(agent.get_tool_lookups())
+        await _wait_until(lambda: observer.of(MCPConnectionOpening) != [])
+
+        await runtime.close()
+
+        kinds = observer.kinds()
+        assert len(observer.of(MCPConnectionAborted)) == 1
+        assert kinds.index(MCPConnectionAborted) < kinds.index(MCPRuntimeShutdownCompleted)
+        _InstrumentedAdapter.connect_gate.set()
+        await asyncio.gather(acquisition, return_exceptions=True)
+        assert len(observer.of(MCPConnectionAborted)) == 1
+
+    @pytest.mark.asyncio
+    async def test_resistant_close_is_terminal_before_shutdown_completes(self) -> None:
+        observer = _RecordingObserver()
+        runtime = MCPRuntime(observer=observer, idle_timeout=None, shutdown_timeout=0.01)
+        agent = Agent(prompt="test", tool_sources=[_bind(runtime).tools()])
+        await agent.get_tool_lookups()
+        await agent.close()
+        _InstrumentedAdapter.close_gate = asyncio.Event()
+
+        await runtime.close()
+
+        kinds = observer.kinds()
+        closed = observer.of(MCPConnectionClosed)
+        assert len(closed) == 1
+        assert closed[0].clean is False
+        assert kinds.index(MCPConnectionClosed) < kinds.index(MCPRuntimeShutdownCompleted)
+        _InstrumentedAdapter.close_gate.set()
+        await _wait_until(lambda: _InstrumentedAdapter.instances[0].closed)
+        assert len(observer.of(MCPConnectionClosed)) == 1
+
+    @pytest.mark.asyncio
+    async def test_resistant_call_is_terminal_when_forced_capacity_is_reclaimed(self) -> None:
+        _InstrumentedAdapter.call_gate = asyncio.Event()
+        _InstrumentedAdapter.suppress_call_cancel = True
+        observer = _RecordingObserver()
+        async with MCPRuntime(observer=observer, shutdown_timeout=0.05) as runtime:
+            connection = _bind(runtime)
+            agent = Agent(prompt="test", tool_sources=[connection.tools()])
+            lookups = await agent.get_tool_lookups()
+            call = asyncio.create_task(lookups.fn["github__write"](value="hostile"))
+            await _await_first_call(_InstrumentedAdapter.instances[0])
+
+            await runtime.evict(connection_key="github-1", mode="force")
+
+            try:
+                assert len(observer.of(MCPToolCallOutcomeUnknown)) == 1
+                assert observer.kinds().index(MCPToolCallOutcomeUnknown) < observer.kinds().index(
+                    MCPEvictionCompleted
+                )
+            finally:
+                _InstrumentedAdapter.call_gate.set()
+            with pytest.raises(MCPOutcomeUnknownError):
+                await call
+            assert len(observer.of(MCPToolCallOutcomeUnknown)) == 1
+            await agent.close()
+
+    @pytest.mark.asyncio
+    async def test_live_rebind_keeps_physical_source_name_stable(self) -> None:
+        observer = _RecordingObserver()
+        async with MCPRuntime(observer=observer, shutdown_timeout=0.05) as runtime:
+            first_connection = _bind(runtime)
+            first = Agent(prompt="first", tool_sources=[first_connection.tools()])
+            await first.get_tool_lookups()
+
+            renamed = runtime.bind(
+                connection_key="github-1",
+                source=MCPSource.http("github_alias", "https://mcp.example.com"),
+            )
+            second = Agent(prompt="second", tool_sources=[renamed.tools()])
+            lookups = await second.get_tool_lookups()
+            assert await lookups.fn["github_alias__read"](value=1) == "read:ok"
+
+            opened = observer.of(MCPConnectionOpened)[0]
+            started = observer.of(MCPToolCallStarted)[0]
+            completed = observer.of(MCPToolCallCompleted)[0]
+            assert started.instance_id == completed.instance_id == opened.instance_id
+            assert started.source_name == completed.source_name == opened.source_name == "github"
+            await second.close()
+            await first.close()

--- a/packages/python/tests/unit/test_mcp_runtime_live.py
+++ b/packages/python/tests/unit/test_mcp_runtime_live.py
@@ -20,11 +20,13 @@ from mcp.types import CallToolResult, TextContent, Tool, ToolAnnotations
 from dendrux.agent import Agent
 from dendrux.mcp._client import MCPConnectionInfo
 from dendrux.mcp._errors import (
+    MCPAuthenticationError,
     MCPBindingConflictError,
     MCPCallCapacityError,
     MCPCapacityError,
     MCPConnectionCapacityError,
     MCPConnectionEvictingError,
+    MCPConnectionLostError,
     MCPCredentialError,
     MCPOutcomeUnknownError,
     MCPRuntimeClosedError,
@@ -1980,7 +1982,7 @@ class TestTypedFailureModes:
 
     @pytest.mark.asyncio
     async def test_ordinary_tool_failure_is_not_reported_as_unknown_outcome(self) -> None:
-        _InstrumentedAdapter.call_error = ConnectionError("server exploded")
+        _InstrumentedAdapter.call_error = RuntimeError("server exploded")
         async with MCPRuntime(shutdown_timeout=0.05) as runtime:
             agent = Agent(prompt="test", tool_sources=[_bind(runtime).tools()])
             lookups = await agent.get_tool_lookups()
@@ -3404,7 +3406,7 @@ class TestCallConcurrency:
 
     @pytest.mark.asyncio
     async def test_a_failed_call_releases_its_slot(self) -> None:
-        _InstrumentedAdapter.call_error = ConnectionError("server exploded")
+        _InstrumentedAdapter.call_error = RuntimeError("server exploded")
         async with MCPRuntime(
             max_in_flight_calls=1, call_wait_timeout=0, shutdown_timeout=0.05
         ) as runtime:
@@ -4041,3 +4043,532 @@ class TestCallConcurrency:
         for invalid in (-1.0, float("nan"), "5"):
             with pytest.raises(ValueError, match="call_wait_timeout"):
                 MCPRuntime(call_wait_timeout=invalid)  # type: ignore[arg-type]
+
+
+class TestBrokenConnectionRecovery:
+    """A dead transport is fenced once, retired, and replaced lazily.
+
+    The failed in-flight call reports an unknown outcome — the server may
+    already have received it — and is never retried by the runtime. Recovery
+    only clears the way for future work: the registration and generation
+    survive, so the same handle reconnects with freshly resolved credentials
+    on its next acquisition.
+    """
+
+    @pytest.mark.asyncio
+    async def test_transport_loss_mid_call_reports_unknown_outcome(self) -> None:
+        _InstrumentedAdapter.call_error = ConnectionResetError("socket died")
+        async with MCPRuntime(shutdown_timeout=0.05) as runtime:
+            agent = Agent(prompt="test", tool_sources=[_bind(runtime).tools()])
+            lookups = await agent.get_tool_lookups()
+
+            with pytest.raises(MCPOutcomeUnknownError) as excinfo:
+                await lookups.fn["github__write"](value=1)
+
+            assert "must not be retried" in str(excinfo.value)
+            assert isinstance(excinfo.value.__cause__, MCPToolCallError)
+            assert runtime._in_flight_calls == 0
+            await agent.close()
+
+    @pytest.mark.asyncio
+    async def test_next_acquisition_reconnects_after_recovery(self) -> None:
+        _InstrumentedAdapter.call_error = ConnectionResetError("socket died")
+        async with MCPRuntime(shutdown_timeout=0.05) as runtime:
+            connection = _bind(runtime)
+            first = Agent(prompt="first", tool_sources=[connection.tools()])
+            lookups = await first.get_tool_lookups()
+            broken = _InstrumentedAdapter.instances[0]
+
+            with pytest.raises(MCPOutcomeUnknownError):
+                await lookups.fn["github__write"](value=1)
+
+            await _wait_until(lambda: broken.closed and runtime._entries == {})
+            _InstrumentedAdapter.call_error = None
+
+            second = Agent(prompt="second", tool_sources=[connection.tools()])
+            fresh = await second.get_tool_lookups()
+            assert await fresh.fn["github__write"](value=2) == "write:ok"
+            assert len(_InstrumentedAdapter.instances) == 2
+
+            # The first Agent's view is still bound to the dead transport:
+            # its retained executor fails typed, and nothing was ever sent.
+            with pytest.raises(MCPConnectionLostError) as excinfo:
+                await lookups.fn["github__write"](value=3)
+            assert excinfo.value.identity == (None, "github-1")
+            assert not isinstance(excinfo.value, MCPToolCallError)
+            assert broken.call_tool_calls == 1
+
+            await first.close()
+            await second.close()
+
+    @pytest.mark.asyncio
+    async def test_recovery_resolves_fresh_credentials_for_the_same_handle(self) -> None:
+        provider = _Credentials(
+            {"Authorization": "Bearer token-1"},
+            {"Authorization": "Bearer token-2"},
+        )
+        _InstrumentedAdapter.call_error = ConnectionResetError("socket died")
+        async with MCPRuntime(shutdown_timeout=0.05) as runtime:
+            connection = _bind(runtime, credentials=provider)
+            first = Agent(prompt="first", tool_sources=[connection.tools()])
+            lookups = await first.get_tool_lookups()
+            opened = _InstrumentedAdapter.instances[0]
+            assert opened.source.headers["Authorization"] == "Bearer token-1"
+
+            with pytest.raises(MCPOutcomeUnknownError):
+                await lookups.fn["github__write"](value=1)
+            await _wait_until(lambda: runtime._entries == {})
+            _InstrumentedAdapter.call_error = None
+
+            second = Agent(prompt="second", tool_sources=[connection.tools()])
+            await second.get_tool_lookups()
+
+            assert provider.calls == 2
+            replacement = _InstrumentedAdapter.instances[1]
+            assert replacement.source.headers["Authorization"] == "Bearer token-2"
+            await first.close()
+            await second.close()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_failures_share_one_recovery(self) -> None:
+        gate = asyncio.Event()
+        _InstrumentedAdapter.call_gate = gate
+        async with MCPRuntime(shutdown_timeout=0.05) as runtime:
+            agent = Agent(prompt="test", tool_sources=[_bind(runtime).tools()])
+            lookups = await agent.get_tool_lookups()
+            adapter = _InstrumentedAdapter.instances[0]
+
+            calls = [
+                asyncio.create_task(lookups.fn["github__write"](value=index)) for index in range(10)
+            ]
+            await _wait_until(lambda: _InstrumentedAdapter.in_call == 10)
+            _InstrumentedAdapter.call_error = ConnectionResetError("socket died")
+            gate.set()
+
+            results = await asyncio.gather(*calls, return_exceptions=True)
+            assert all(isinstance(result, MCPOutcomeUnknownError) for result in results)
+
+            await _wait_until(lambda: adapter.closed and runtime._entries == {})
+            assert adapter.close_calls == 1
+            assert len(_InstrumentedAdapter.instances) == 1
+            await agent.close()
+
+    @pytest.mark.asyncio
+    async def test_recovery_interrupts_other_in_flight_calls_as_outcome_unknown(self) -> None:
+        """Closing one shared SDK client can cancel its other request waiters;
+        those calls were admitted and must not leak bare cancellation."""
+
+        class _SiblingAdapter(_InstrumentedAdapter):
+            sibling_started = asyncio.Event()
+
+            async def call_tool(
+                self,
+                name: str,
+                arguments: dict[str, Any],
+            ) -> CallToolResult:
+                self.call_tool_calls += 1
+                if arguments["value"] == "dies":
+                    await self.sibling_started.wait()
+                    raise ConnectionResetError("socket died")
+                self.sibling_started.set()
+                await asyncio.Event().wait()
+                raise AssertionError("unreachable")
+
+        with patch("dendrux.mcp._runtime.MCPClientAdapter", _SiblingAdapter):
+            async with MCPRuntime(shutdown_timeout=0.05) as runtime:
+                agent = Agent(prompt="test", tool_sources=[_bind(runtime).tools()])
+                lookups = await agent.get_tool_lookups()
+
+                sibling = asyncio.create_task(lookups.fn["github__write"](value="sibling"))
+                await _SiblingAdapter.sibling_started.wait()
+                failing = asyncio.create_task(lookups.fn["github__write"](value="dies"))
+
+                results = await asyncio.gather(failing, sibling, return_exceptions=True)
+
+                assert all(isinstance(result, MCPOutcomeUnknownError) for result in results)
+                assert all("lost connection" in str(result) for result in results)
+                assert runtime._in_flight_calls == 0
+                await agent.close()
+
+    @pytest.mark.asyncio
+    async def test_recovery_reclaims_a_resistant_sibling_call_permit(self) -> None:
+        """A request that ignores the recovery cancellation cannot retain a
+        global call slot or delay opening the replacement connection."""
+
+        class _ResistantSiblingAdapter(_InstrumentedAdapter):
+            sibling_started = asyncio.Event()
+            release_sibling = asyncio.Event()
+
+            async def call_tool(
+                self,
+                name: str,
+                arguments: dict[str, Any],
+            ) -> CallToolResult:
+                self.call_tool_calls += 1
+                if arguments["value"] == "dies":
+                    await self.sibling_started.wait()
+                    raise ConnectionResetError("socket died")
+                self.sibling_started.set()
+                while True:
+                    try:
+                        await self.release_sibling.wait()
+                        return CallToolResult(content=[TextContent(text="late:ok")])
+                    except asyncio.CancelledError:
+                        continue
+
+        with patch("dendrux.mcp._runtime.MCPClientAdapter", _ResistantSiblingAdapter):
+            runtime = MCPRuntime(max_in_flight_calls=2, shutdown_timeout=0.05)
+            connection = _bind(runtime)
+            agent = Agent(prompt="test", tool_sources=[connection.tools()])
+            lookups = await agent.get_tool_lookups()
+            sibling = asyncio.create_task(lookups.fn["github__write"](value="sibling"))
+            await _ResistantSiblingAdapter.sibling_started.wait()
+
+            with pytest.raises(MCPOutcomeUnknownError):
+                await lookups.fn["github__write"](value="dies")
+
+            await _wait_until(lambda: runtime._entries == {})
+            assert runtime._in_flight_calls == 0
+
+            replacement = Agent(prompt="replacement", tool_sources=[connection.tools()])
+            await asyncio.wait_for(replacement.get_tool_lookups(), timeout=1.0)
+
+            _ResistantSiblingAdapter.release_sibling.set()
+            assert await asyncio.wait_for(sibling, timeout=1.0) == "late:ok"
+            await agent.close()
+            await replacement.close()
+            await runtime.close()
+
+    @pytest.mark.asyncio
+    async def test_recovery_restores_the_caller_cancellation_count(self) -> None:
+        """Absorbing the runtime's cancellation must not poison an outer
+        timeout or TaskGroup owned by the application."""
+
+        class _SiblingAdapter(_InstrumentedAdapter):
+            sibling_started = asyncio.Event()
+
+            async def call_tool(
+                self,
+                name: str,
+                arguments: dict[str, Any],
+            ) -> CallToolResult:
+                self.call_tool_calls += 1
+                if arguments["value"] == "dies":
+                    await self.sibling_started.wait()
+                    raise ConnectionResetError("socket died")
+                self.sibling_started.set()
+                await asyncio.Event().wait()
+                raise AssertionError("unreachable")
+
+        with patch("dendrux.mcp._runtime.MCPClientAdapter", _SiblingAdapter):
+            runtime = MCPRuntime(shutdown_timeout=0.05)
+            agent = Agent(prompt="test", tool_sources=[_bind(runtime).tools()])
+            call = (await agent.get_tool_lookups()).fn["github__write"]
+            converted = asyncio.Event()
+            finish = asyncio.Event()
+            observed: dict[str, int] = {}
+
+            async def caller() -> None:
+                task = asyncio.current_task()
+                assert task is not None
+                observed["before"] = task.cancelling()
+                with pytest.raises(MCPOutcomeUnknownError, match="lost connection"):
+                    await call(value="sibling")
+                observed["after"] = task.cancelling()
+                converted.set()
+                await finish.wait()
+
+            sibling = asyncio.create_task(caller())
+            await _SiblingAdapter.sibling_started.wait()
+            with pytest.raises(MCPOutcomeUnknownError):
+                await call(value="dies")
+            await asyncio.wait_for(converted.wait(), timeout=1.0)
+
+            assert observed == {"before": 0, "after": 0}
+            finish.set()
+            await sibling
+            await agent.close()
+            await runtime.close()
+
+    @pytest.mark.asyncio
+    async def test_application_cancellation_survives_recovery_interruption(self) -> None:
+        """A user cancellation racing the runtime's recovery cancellation
+        remains cancellation rather than becoming an MCP tool error."""
+
+        class _SiblingAdapter(_InstrumentedAdapter):
+            sibling_started = asyncio.Event()
+            runtime_cancel_seen = asyncio.Event()
+
+            async def call_tool(
+                self,
+                name: str,
+                arguments: dict[str, Any],
+            ) -> CallToolResult:
+                self.call_tool_calls += 1
+                if arguments["value"] == "dies":
+                    await self.sibling_started.wait()
+                    raise ConnectionResetError("socket died")
+                self.sibling_started.set()
+                try:
+                    await asyncio.Event().wait()
+                except asyncio.CancelledError:
+                    self.runtime_cancel_seen.set()
+                    await asyncio.Event().wait()
+                    raise
+
+        with patch("dendrux.mcp._runtime.MCPClientAdapter", _SiblingAdapter):
+            runtime = MCPRuntime(shutdown_timeout=0.05)
+            agent = Agent(prompt="test", tool_sources=[_bind(runtime).tools()])
+            call = (await agent.get_tool_lookups()).fn["github__write"]
+            sibling = asyncio.create_task(call(value="sibling"))
+            await _SiblingAdapter.sibling_started.wait()
+
+            with pytest.raises(MCPOutcomeUnknownError):
+                await call(value="dies")
+            await asyncio.wait_for(_SiblingAdapter.runtime_cancel_seen.wait(), timeout=1.0)
+            sibling.cancel()
+
+            with pytest.raises(asyncio.CancelledError):
+                await sibling
+            assert sibling.cancelling() == 1
+            assert runtime._in_flight_calls == 0
+            await agent.close()
+            await runtime.close()
+
+    @pytest.mark.asyncio
+    async def test_queued_calls_never_enter_the_broken_transport(self) -> None:
+        gate = asyncio.Event()
+        _InstrumentedAdapter.call_gate = gate
+        async with MCPRuntime(
+            max_in_flight_calls=1, call_wait_timeout=5.0, shutdown_timeout=0.05
+        ) as runtime:
+            agent = Agent(prompt="test", tool_sources=[_bind(runtime).tools()])
+            lookups = await agent.get_tool_lookups()
+            adapter = _InstrumentedAdapter.instances[0]
+
+            busy = asyncio.create_task(lookups.fn["github__write"](value="busy"))
+            await _await_first_call(adapter)
+            queued = asyncio.create_task(lookups.fn["github__write"](value="queued"))
+            await _wait_until(lambda: len(runtime._call_queue) == 1)
+
+            _InstrumentedAdapter.call_error = BrokenPipeError("pipe closed")
+            gate.set()
+
+            with pytest.raises(MCPOutcomeUnknownError):
+                await busy
+            # Well inside the 5s wait budget: the fence wakes the queue.
+            with pytest.raises(MCPConnectionLostError):
+                await asyncio.wait_for(queued, timeout=1.0)
+            assert adapter.call_tool_calls == 1
+            await agent.close()
+
+    @pytest.mark.asyncio
+    async def test_ordinary_tool_failures_do_not_poison_the_connection(self) -> None:
+        _InstrumentedAdapter.call_error = RuntimeError("tool exploded")
+        async with MCPRuntime(shutdown_timeout=0.05) as runtime:
+            agent = Agent(prompt="test", tool_sources=[_bind(runtime).tools()])
+            lookups = await agent.get_tool_lookups()
+
+            with pytest.raises(MCPToolCallError) as excinfo:
+                await lookups.fn["github__write"](value=1)
+            assert not isinstance(excinfo.value, MCPOutcomeUnknownError)
+
+            entry = runtime._entries[(None, "github-1")]
+            assert entry.broken is False
+            assert entry.fenced is False
+
+            _InstrumentedAdapter.call_error = None
+            assert await lookups.fn["github__write"](value=2) == "write:ok"
+            assert len(_InstrumentedAdapter.instances) == 1
+            await agent.close()
+
+    @pytest.mark.asyncio
+    async def test_credential_rejection_mid_call_does_not_reconnect(self) -> None:
+        class _RejectedError(RuntimeError):
+            status_code = 401
+
+        _InstrumentedAdapter.call_error = _RejectedError("401 Unauthorized")
+        async with MCPRuntime(shutdown_timeout=0.05) as runtime:
+            agent = Agent(prompt="test", tool_sources=[_bind(runtime).tools()])
+            lookups = await agent.get_tool_lookups()
+
+            # A rejection arrives over a WORKING transport: refreshing
+            # credentials is the application's move, not reconnection.
+            for attempt in (1, 2):
+                with pytest.raises(MCPToolCallError) as excinfo:
+                    await lookups.fn["github__write"](value=attempt)
+                assert not isinstance(excinfo.value, MCPOutcomeUnknownError)
+
+            assert len(_InstrumentedAdapter.instances) == 1
+            assert _InstrumentedAdapter.instances[0].closed is False
+            assert _total_connects() == 1
+            await agent.close()
+
+    @pytest.mark.asyncio
+    async def test_connect_time_rejection_does_not_reconnect_in_a_loop(self) -> None:
+        _InstrumentedAdapter.connect_error = MCPAuthenticationError(
+            "Failed to connect to MCP source 'github': "
+            "the server rejected its credentials (HTTP 401)."
+        )
+        async with MCPRuntime(shutdown_timeout=0.05) as runtime:
+            connection = _bind(runtime)
+            for _ in range(2):
+                agent = Agent(prompt="test", tool_sources=[connection.tools()])
+                with pytest.raises(MCPAuthenticationError):
+                    await agent.get_tool_lookups()
+
+            # One connect attempt per explicit acquisition; the runtime never
+            # retries a credential rejection on its own.
+            assert _total_connects() == 2
+            assert runtime._entries == {}
+
+    @pytest.mark.asyncio
+    async def test_application_cancellation_does_not_mark_the_connection_broken(self) -> None:
+        gate = asyncio.Event()
+        _InstrumentedAdapter.call_gate = gate
+        async with MCPRuntime(shutdown_timeout=0.05) as runtime:
+            agent = Agent(prompt="test", tool_sources=[_bind(runtime).tools()])
+            lookups = await agent.get_tool_lookups()
+            adapter = _InstrumentedAdapter.instances[0]
+
+            call = asyncio.create_task(lookups.fn["github__write"](value="cancel-me"))
+            await _await_first_call(adapter)
+            call.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await call
+
+            entry = runtime._entries[(None, "github-1")]
+            assert entry.broken is False
+            assert entry.fenced is False
+
+            gate.set()
+            assert await lookups.fn["github__write"](value="next") == "write:ok"
+            assert len(_InstrumentedAdapter.instances) == 1
+            await agent.close()
+
+    @pytest.mark.asyncio
+    async def test_recovery_frees_the_connection_slot(self) -> None:
+        _InstrumentedAdapter.call_error = ConnectionResetError("socket died")
+        async with MCPRuntime(
+            max_connections=1, connection_wait_timeout=5.0, shutdown_timeout=0.05
+        ) as runtime:
+            github = _bind(runtime)
+            first = Agent(prompt="first", tool_sources=[github.tools()])
+            lookups = await first.get_tool_lookups()
+
+            with pytest.raises(MCPOutcomeUnknownError):
+                await lookups.fn["github__write"](value=1)
+            _InstrumentedAdapter.call_error = None
+
+            # The first Agent still holds its lease on the dead entry, yet
+            # the slot frees for a different identity once recovery discards
+            # the broken transport.
+            jira = _bind(runtime, connection_key="jira-1")
+            second = Agent(prompt="second", tool_sources=[jira.tools(namespace="jira")])
+            fresh = await asyncio.wait_for(second.get_tool_lookups(), timeout=1.0)
+            assert await fresh.fn["jira__write"](value=2) == "write:ok"
+            await first.close()
+            await second.close()
+
+    @pytest.mark.asyncio
+    async def test_recovery_racing_eviction_does_not_double_close(self) -> None:
+        _InstrumentedAdapter.call_error = ConnectionResetError("socket died")
+        async with MCPRuntime(shutdown_timeout=0.05) as runtime:
+            agent = Agent(prompt="test", tool_sources=[_bind(runtime).tools()])
+            lookups = await agent.get_tool_lookups()
+            adapter = _InstrumentedAdapter.instances[0]
+
+            with pytest.raises(MCPOutcomeUnknownError):
+                await lookups.fn["github__write"](value=1)
+            await asyncio.wait_for(
+                runtime.evict(connection_key="github-1", mode="force"),
+                timeout=1.0,
+            )
+            await _wait_until(lambda: adapter.closed and not runtime._evictions)
+
+            assert adapter.close_calls == 1
+            assert runtime._entries == {}
+            assert (None, "github-1") not in runtime._registrations
+            with pytest.raises(MCPStaleConnectionError):
+                await lookups.fn["github__write"](value="after-eviction")
+
+            replacement_connection = _bind(runtime)
+            replacement = Agent(
+                prompt="replacement",
+                tool_sources=[replacement_connection.tools()],
+            )
+            await replacement.get_tool_lookups()
+            with pytest.raises(MCPStaleConnectionError):
+                await lookups.fn["github__write"](value="after-rebind")
+            await replacement.close()
+            await agent.close()
+
+    @pytest.mark.asyncio
+    async def test_recovery_racing_shutdown_does_not_double_close(self) -> None:
+        _InstrumentedAdapter.call_error = ConnectionResetError("socket died")
+        runtime = MCPRuntime(shutdown_timeout=0.5)
+        agent = Agent(prompt="test", tool_sources=[_bind(runtime).tools()])
+        lookups = await agent.get_tool_lookups()
+        adapter = _InstrumentedAdapter.instances[0]
+
+        with pytest.raises(MCPOutcomeUnknownError):
+            await lookups.fn["github__write"](value=1)
+        await agent.close()
+        await asyncio.wait_for(runtime.close(), timeout=1.0)
+
+        assert adapter.close_calls == 1
+        assert runtime.state is MCPRuntimeState.CLOSED
+
+    @pytest.mark.asyncio
+    async def test_resistant_transport_does_not_block_recovery(self) -> None:
+        close_gate = asyncio.Event()
+        _InstrumentedAdapter.close_gate = close_gate
+        _InstrumentedAdapter.call_error = ConnectionResetError("socket died")
+        async with MCPRuntime(shutdown_timeout=0.05) as runtime:
+            connection = _bind(runtime)
+            first = Agent(prompt="first", tool_sources=[connection.tools()])
+            lookups = await first.get_tool_lookups()
+
+            with pytest.raises(MCPOutcomeUnknownError):
+                await lookups.fn["github__write"](value=1)
+
+            # The broken transport never finishes closing, yet the slot frees
+            # after the bounded grace and a replacement can open.
+            await _wait_until(lambda: runtime._entries == {})
+            _InstrumentedAdapter.call_error = None
+            second = Agent(prompt="second", tool_sources=[connection.tools()])
+            fresh = await asyncio.wait_for(second.get_tool_lookups(), timeout=1.0)
+            assert await fresh.fn["github__write"](value=2) == "write:ok"
+
+            close_gate.set()  # release the abandoned cleanup before shutdown
+            await first.close()
+            await second.close()
+
+    @pytest.mark.asyncio
+    async def test_recovery_is_scoped_to_one_tenant_partition(self) -> None:
+        async with MCPRuntime(shutdown_timeout=0.05) as runtime:
+            alpha = _bind(runtime, tenant_key="tenant-alpha")
+            beta = _bind(runtime, tenant_key="tenant-beta")
+            agent_alpha = Agent(prompt="alpha", tool_sources=[alpha.tools()])
+            agent_beta = Agent(prompt="beta", tool_sources=[beta.tools()])
+            lookups_alpha = await agent_alpha.get_tool_lookups()
+            lookups_beta = await agent_beta.get_tool_lookups()
+
+            _InstrumentedAdapter.call_error = ConnectionResetError("socket died")
+            with pytest.raises(MCPOutcomeUnknownError):
+                await lookups_alpha.fn["github__write"](value=1)
+            _InstrumentedAdapter.call_error = None
+
+            assert await lookups_beta.fn["github__write"](value=2) == "write:ok"
+            await _wait_until(lambda: ("tenant-alpha", "github-1") not in runtime._entries)
+            assert ("tenant-beta", "github-1") in runtime._entries
+            assert _InstrumentedAdapter.instances[1].close_calls == 0
+
+            replacement = Agent(prompt="alpha-2", tool_sources=[alpha.tools()])
+            fresh = await replacement.get_tool_lookups()
+            assert await fresh.fn["github__write"](value=3) == "write:ok"
+            assert len(_InstrumentedAdapter.instances) == 3
+
+            await agent_alpha.close()
+            await agent_beta.close()
+            await replacement.close()

--- a/packages/python/tests/unit/test_mcp_runtime_live.py
+++ b/packages/python/tests/unit/test_mcp_runtime_live.py
@@ -24,6 +24,7 @@ from dendrux.mcp._errors import (
     MCPBindingConflictError,
     MCPCallCapacityError,
     MCPCapacityError,
+    MCPCircuitOpenError,
     MCPConnectionCapacityError,
     MCPConnectionEvictingError,
     MCPConnectionLostError,
@@ -37,6 +38,7 @@ from dendrux.mcp._runtime import (
     MCPConnection,
     MCPRuntime,
     MCPRuntimeState,
+    _ConnectionEntry,
     _resolve_source_credentials,
     _ViewToolSource,
 )
@@ -4572,3 +4574,592 @@ class TestBrokenConnectionRecovery:
             await agent_alpha.close()
             await agent_beta.close()
             await replacement.close()
+
+
+class TestCircuitBreaker:
+    """Repeated connection failures open a per-identity circuit.
+
+    An unavailable server must not absorb a reconnect storm: once the
+    threshold of consecutive failures is reached, acquisitions fail fast
+    with a typed error carrying ``retry_after``. After the cooldown exactly
+    one probe connection is attempted — concurrent callers wait behind it —
+    and a successful connection closes the circuit again. The breaker gates
+    only new physical connections; it never retries tool calls.
+    """
+
+    @pytest.mark.asyncio
+    async def test_repeated_connect_failures_open_the_circuit(self) -> None:
+        _InstrumentedAdapter.connect_error = ConnectionError("server down")
+        async with MCPRuntime(
+            circuit_failure_threshold=3, circuit_reset_timeout=30.0, shutdown_timeout=0.05
+        ) as runtime:
+            connection = _bind(runtime)
+            for _ in range(3):
+                agent = Agent(prompt="test", tool_sources=[connection.tools()])
+                with pytest.raises(ConnectionError):
+                    await agent.get_tool_lookups()
+
+            rejected = Agent(prompt="rejected", tool_sources=[connection.tools()])
+            with pytest.raises(MCPCircuitOpenError) as excinfo:
+                # Well under every wait budget: an open circuit never queues.
+                await asyncio.wait_for(rejected.get_tool_lookups(), timeout=1.0)
+
+            error = excinfo.value
+            assert error.identity == (None, "github-1")
+            assert 0 < error.retry_after <= 30.0
+            assert error.failure_count == 3
+            assert error.last_failure == "ConnectionError"
+            assert "circuit is open" in str(error)
+            # Failing fast means the server was never contacted again.
+            assert _total_connects() == 3
+            assert runtime._entries == {}
+
+    @pytest.mark.asyncio
+    async def test_cooldown_admits_exactly_one_probe(self) -> None:
+        _InstrumentedAdapter.connect_error = ConnectionError("server down")
+        async with MCPRuntime(
+            circuit_failure_threshold=2, circuit_reset_timeout=0.1, shutdown_timeout=0.05
+        ) as runtime:
+            connection = _bind(runtime)
+            for _ in range(2):
+                agent = Agent(prompt="test", tool_sources=[connection.tools()])
+                with pytest.raises(ConnectionError):
+                    await agent.get_tool_lookups()
+            await asyncio.sleep(0.15)
+
+            gate = asyncio.Event()
+            _InstrumentedAdapter.connect_gate = gate
+            probers = [
+                Agent(prompt=f"probe-{index}", tool_sources=[connection.tools()])
+                for index in range(3)
+            ]
+            acquisitions = [asyncio.create_task(agent.get_tool_lookups()) for agent in probers]
+            await _wait_until(
+                lambda: (
+                    (None, "github-1") in runtime._entries
+                    and runtime._entries[(None, "github-1")].leases == 3
+                )
+            )
+            # Every concurrent caller shares the single probe connection.
+            assert _total_connects() == 3
+            gate.set()
+
+            results = await asyncio.gather(*acquisitions, return_exceptions=True)
+            assert all(isinstance(result, ConnectionError) for result in results)
+
+            # The failed probe counted one more failure and re-armed the
+            # cooldown, so the circuit is open again.
+            circuit = runtime._registrations[(None, "github-1")].circuit
+            assert circuit.consecutive_failures == 3
+            assert circuit.open_until is not None
+            assert runtime._entries == {}
+
+    @pytest.mark.asyncio
+    async def test_callers_wait_behind_a_successful_probe(self) -> None:
+        _InstrumentedAdapter.connect_error = ConnectionError("server down")
+        async with MCPRuntime(
+            circuit_failure_threshold=2, circuit_reset_timeout=0.1, shutdown_timeout=0.05
+        ) as runtime:
+            connection = _bind(runtime)
+            for _ in range(2):
+                agent = Agent(prompt="test", tool_sources=[connection.tools()])
+                with pytest.raises(ConnectionError):
+                    await agent.get_tool_lookups()
+            await asyncio.sleep(0.15)
+            _InstrumentedAdapter.connect_error = None
+
+            gate = asyncio.Event()
+            _InstrumentedAdapter.connect_gate = gate
+            probers = [
+                Agent(prompt=f"probe-{index}", tool_sources=[connection.tools()])
+                for index in range(3)
+            ]
+            acquisitions = [asyncio.create_task(agent.get_tool_lookups()) for agent in probers]
+            await _wait_until(
+                lambda: (
+                    (None, "github-1") in runtime._entries
+                    and runtime._entries[(None, "github-1")].leases == 3
+                )
+            )
+            gate.set()
+
+            for lookups in await asyncio.gather(*acquisitions):
+                assert await lookups.fn["github__read"](value=1) == "read:ok"
+            # Two failed attempts, then one shared probe connection.
+            assert _total_connects() == 3
+            circuit = runtime._registrations[(None, "github-1")].circuit
+            assert circuit.consecutive_failures == 0
+            assert circuit.open_until is None
+            for agent in probers:
+                await agent.close()
+
+    @pytest.mark.asyncio
+    async def test_a_successful_connection_resets_the_failure_count(self) -> None:
+        async with MCPRuntime(
+            circuit_failure_threshold=2,
+            circuit_reset_timeout=30.0,
+            idle_timeout=0.0,
+            shutdown_timeout=0.05,
+        ) as runtime:
+            connection = _bind(runtime)
+
+            async def failing_acquisition() -> None:
+                agent = Agent(prompt="fail", tool_sources=[connection.tools()])
+                with pytest.raises(ConnectionError):
+                    await agent.get_tool_lookups()
+
+            _InstrumentedAdapter.connect_error = ConnectionError("blip")
+            await failing_acquisition()  # one short of the threshold
+
+            _InstrumentedAdapter.connect_error = None
+            agent = Agent(prompt="ok", tool_sources=[connection.tools()])
+            await agent.get_tool_lookups()
+            await agent.close()
+            await _wait_until(lambda: runtime._entries == {})  # idle retirement
+
+            # The success cleared the count: the threshold must be reached
+            # from scratch before the circuit opens again.
+            _InstrumentedAdapter.connect_error = ConnectionError("blip")
+            await failing_acquisition()
+            await failing_acquisition()
+            blocked = Agent(prompt="blocked", tool_sources=[connection.tools()])
+            with pytest.raises(MCPCircuitOpenError):
+                await blocked.get_tool_lookups()
+            assert _total_connects() == 4
+
+    @pytest.mark.asyncio
+    async def test_transport_loss_counts_toward_the_circuit(self) -> None:
+        _InstrumentedAdapter.call_error = ConnectionResetError("socket died")
+        async with MCPRuntime(
+            circuit_failure_threshold=2, circuit_reset_timeout=30.0, shutdown_timeout=0.05
+        ) as runtime:
+            connection = _bind(runtime)
+            agent = Agent(prompt="test", tool_sources=[connection.tools()])
+            lookups = await agent.get_tool_lookups()
+
+            with pytest.raises(MCPOutcomeUnknownError):
+                await lookups.fn["github__write"](value=1)
+            await _wait_until(lambda: runtime._entries == {})
+
+            # The mid-call loss (1) plus one failed reconnect (2) reaches the
+            # threshold without a second connect failure.
+            _InstrumentedAdapter.connect_error = ConnectionError("still down")
+            reconnect = Agent(prompt="reconnect", tool_sources=[connection.tools()])
+            with pytest.raises(ConnectionError):
+                await reconnect.get_tool_lookups()
+
+            blocked = Agent(prompt="blocked", tool_sources=[connection.tools()])
+            with pytest.raises(MCPCircuitOpenError) as excinfo:
+                await blocked.get_tool_lookups()
+            assert excinfo.value.failure_count == 2
+            assert _total_connects() == 2
+            await agent.close()
+
+    @pytest.mark.asyncio
+    async def test_repeated_mid_call_losses_open_the_circuit(self) -> None:
+        _InstrumentedAdapter.call_error = ConnectionResetError("socket died")
+        async with MCPRuntime(
+            circuit_failure_threshold=2,
+            circuit_reset_timeout=30.0,
+            shutdown_timeout=0.05,
+        ) as runtime:
+            connection = _bind(runtime)
+
+            for _ in range(2):
+                agent = Agent(prompt="test", tool_sources=[connection.tools()])
+                lookups = await agent.get_tool_lookups()
+                with pytest.raises(MCPOutcomeUnknownError):
+                    await lookups.fn["github__write"](value=1)
+                await _wait_until(lambda: runtime._entries == {})
+                await agent.close()
+
+            blocked = Agent(prompt="blocked", tool_sources=[connection.tools()])
+            with pytest.raises(MCPCircuitOpenError) as excinfo:
+                await blocked.get_tool_lookups()
+
+            assert excinfo.value.failure_count == 2
+            assert excinfo.value.last_failure == "connection loss"
+            assert _total_connects() == 2
+
+    @pytest.mark.asyncio
+    async def test_confirmed_tool_response_resets_the_transport_loss_streak(self) -> None:
+        async with MCPRuntime(
+            circuit_failure_threshold=2,
+            circuit_reset_timeout=30.0,
+            idle_timeout=0.0,
+            shutdown_timeout=0.05,
+        ) as runtime:
+            connection = _bind(runtime)
+
+            _InstrumentedAdapter.call_error = ConnectionResetError("socket died")
+            first = Agent(prompt="first", tool_sources=[connection.tools()])
+            first_tools = await first.get_tool_lookups()
+            with pytest.raises(MCPOutcomeUnknownError):
+                await first_tools.fn["github__write"](value=1)
+            await _wait_until(lambda: runtime._entries == {})
+            await first.close()
+
+            _InstrumentedAdapter.call_error = None
+            healthy = Agent(prompt="healthy", tool_sources=[connection.tools()])
+            healthy_tools = await healthy.get_tool_lookups()
+            assert await healthy_tools.fn["github__write"](value=2) == "write:ok"
+            await healthy.close()
+            await _wait_until(lambda: runtime._entries == {})
+
+            _InstrumentedAdapter.call_error = ConnectionResetError("socket died")
+            third = Agent(prompt="third", tool_sources=[connection.tools()])
+            third_tools = await third.get_tool_lookups()
+            with pytest.raises(MCPOutcomeUnknownError):
+                await third_tools.fn["github__write"](value=3)
+            await _wait_until(lambda: runtime._entries == {})
+            await third.close()
+
+            circuit = runtime._registrations[(None, "github-1")].circuit
+            assert circuit.consecutive_failures == 1
+            assert circuit.open_until is None
+
+    @pytest.mark.asyncio
+    async def test_obsolete_success_cannot_clear_a_newer_failed_attempt(self) -> None:
+        class _LateAdapter:
+            attempts = 0
+            stale_gate = asyncio.Event()
+
+            def __init__(self, source: MCPSource) -> None:
+                self.source = source
+                self.info = None
+                type(self).attempts += 1
+                self.attempt = type(self).attempts
+
+            async def connect(self) -> None:
+                if self.attempt == 1:
+                    while True:
+                        try:
+                            await self.stale_gate.wait()
+                            return
+                        except asyncio.CancelledError:
+                            continue
+                raise ConnectionError("newer attempt failed")
+
+            async def list_tools(self) -> list[Tool]:
+                return []
+
+            async def close(self) -> None:
+                return None
+
+        with patch("dendrux.mcp._runtime.MCPClientAdapter", _LateAdapter):
+            runtime = MCPRuntime(
+                circuit_failure_threshold=1,
+                circuit_reset_timeout=30.0,
+                idle_timeout=0.0,
+                shutdown_timeout=0.01,
+            )
+            connection = _bind(runtime)
+            stale = asyncio.create_task(runtime._lease(connection))
+            await _wait_until(lambda: _LateAdapter.attempts == 1)
+            stale.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await stale
+            await _wait_until(lambda: runtime._entries == {})
+
+            with pytest.raises(ConnectionError):
+                await runtime._lease(connection)
+            circuit = runtime._registrations[(None, "github-1")].circuit
+            assert circuit.open_until is not None
+
+            _LateAdapter.stale_gate.set()
+            await _wait_until(lambda: not runtime._abandoned_tasks)
+
+            assert circuit.consecutive_failures == 1
+            assert circuit.open_until is not None
+            await runtime.close()
+
+    @pytest.mark.asyncio
+    async def test_obsolete_failure_cannot_poison_a_newer_success(self) -> None:
+        class _LateAdapter:
+            attempts = 0
+            stale_gate = asyncio.Event()
+
+            def __init__(self, source: MCPSource) -> None:
+                self.source = source
+                self.info = None
+                type(self).attempts += 1
+                self.attempt = type(self).attempts
+
+            async def connect(self) -> None:
+                if self.attempt != 1:
+                    return
+                while True:
+                    try:
+                        await self.stale_gate.wait()
+                        raise ConnectionError("obsolete attempt failed")
+                    except asyncio.CancelledError:
+                        continue
+
+            async def list_tools(self) -> list[Tool]:
+                return []
+
+            async def close(self) -> None:
+                return None
+
+        with patch("dendrux.mcp._runtime.MCPClientAdapter", _LateAdapter):
+            runtime = MCPRuntime(
+                circuit_failure_threshold=1,
+                circuit_reset_timeout=30.0,
+                idle_timeout=0.0,
+                shutdown_timeout=0.01,
+            )
+            connection = _bind(runtime)
+            stale = asyncio.create_task(runtime._lease(connection))
+            await _wait_until(lambda: _LateAdapter.attempts == 1)
+            stale.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await stale
+            await _wait_until(lambda: runtime._entries == {})
+
+            current = await runtime._lease(connection)
+            circuit = runtime._registrations[(None, "github-1")].circuit
+            assert circuit.consecutive_failures == 0
+
+            _LateAdapter.stale_gate.set()
+            await _wait_until(lambda: not runtime._abandoned_tasks)
+
+            assert circuit.consecutive_failures == 0
+            assert circuit.open_until is None
+            runtime._release((None, "github-1"), current)
+            await runtime.close()
+
+    @pytest.mark.asyncio
+    async def test_authentication_rejections_open_the_circuit(self) -> None:
+        _InstrumentedAdapter.connect_error = MCPAuthenticationError(
+            "Failed to connect to MCP source 'github': "
+            "the server rejected its credentials (HTTP 401)."
+        )
+        async with MCPRuntime(
+            circuit_failure_threshold=2, circuit_reset_timeout=30.0, shutdown_timeout=0.05
+        ) as runtime:
+            connection = _bind(runtime)
+            for _ in range(2):
+                agent = Agent(prompt="test", tool_sources=[connection.tools()])
+                with pytest.raises(MCPAuthenticationError):
+                    await agent.get_tool_lookups()
+
+            # Rejections stop reaching the server: rotating credentials and
+            # rebinding (or evicting) resets, instead of retrying in a loop.
+            blocked = Agent(prompt="blocked", tool_sources=[connection.tools()])
+            with pytest.raises(MCPCircuitOpenError) as excinfo:
+                await blocked.get_tool_lookups()
+            assert excinfo.value.last_failure == "MCPAuthenticationError"
+            assert _total_connects() == 2
+
+    @pytest.mark.asyncio
+    async def test_tenant_partitions_have_independent_circuits(self) -> None:
+        async with MCPRuntime(
+            circuit_failure_threshold=1, circuit_reset_timeout=30.0, shutdown_timeout=0.05
+        ) as runtime:
+            alpha = _bind(runtime, tenant_key="tenant-alpha")
+            beta = _bind(runtime, tenant_key="tenant-beta")
+
+            _InstrumentedAdapter.connect_error = ConnectionError("alpha exploded")
+            agent_alpha = Agent(prompt="alpha", tool_sources=[alpha.tools()])
+            with pytest.raises(ConnectionError):
+                await agent_alpha.get_tool_lookups()
+            _InstrumentedAdapter.connect_error = None
+
+            agent_beta = Agent(prompt="beta", tool_sources=[beta.tools()])
+            lookups = await agent_beta.get_tool_lookups()
+            assert await lookups.fn["github__write"](value=1) == "write:ok"
+
+            blocked = Agent(prompt="alpha-blocked", tool_sources=[alpha.tools()])
+            with pytest.raises(MCPCircuitOpenError) as excinfo:
+                await blocked.get_tool_lookups()
+            assert excinfo.value.identity == ("tenant-alpha", "github-1")
+            await agent_beta.close()
+
+    @pytest.mark.asyncio
+    async def test_eviction_resets_the_circuit(self) -> None:
+        _InstrumentedAdapter.connect_error = ConnectionError("server down")
+        async with MCPRuntime(
+            circuit_failure_threshold=1, circuit_reset_timeout=30.0, shutdown_timeout=0.05
+        ) as runtime:
+            connection = _bind(runtime)
+            agent = Agent(prompt="test", tool_sources=[connection.tools()])
+            with pytest.raises(ConnectionError):
+                await agent.get_tool_lookups()
+            blocked = Agent(prompt="blocked", tool_sources=[connection.tools()])
+            with pytest.raises(MCPCircuitOpenError):
+                await blocked.get_tool_lookups()
+
+            await runtime.evict(connection_key="github-1")
+            _InstrumentedAdapter.connect_error = None
+            rebound = _bind(runtime)
+            fresh = Agent(prompt="fresh", tool_sources=[rebound.tools()])
+            lookups = await fresh.get_tool_lookups()  # no cooldown wait
+            assert await lookups.fn["github__write"](value=1) == "write:ok"
+            await fresh.close()
+
+    @pytest.mark.asyncio
+    async def test_credential_rotation_rebind_resets_the_circuit(self) -> None:
+        rejected = _Credentials({"Authorization": "Bearer expired"})
+        _InstrumentedAdapter.connect_error = MCPAuthenticationError(
+            "Failed to connect to MCP source 'github': "
+            "the server rejected its credentials (HTTP 401)."
+        )
+        async with MCPRuntime(
+            circuit_failure_threshold=1, circuit_reset_timeout=30.0, shutdown_timeout=0.05
+        ) as runtime:
+            stale = _bind(runtime, credentials=rejected, credential_identity="cred-1")
+            agent = Agent(prompt="test", tool_sources=[stale.tools()])
+            with pytest.raises(MCPAuthenticationError):
+                await agent.get_tool_lookups()
+            blocked = Agent(prompt="blocked", tool_sources=[stale.tools()])
+            with pytest.raises(MCPCircuitOpenError):
+                await blocked.get_tool_lookups()
+
+            # Rotating to new credentials is an explicit operator action; it
+            # earns an immediate retry instead of waiting out the cooldown.
+            _InstrumentedAdapter.connect_error = None
+            rotated = _Credentials({"Authorization": "Bearer rotated"})
+            fresh_handle = _bind(runtime, credentials=rotated, credential_identity="cred-2")
+            fresh = Agent(prompt="fresh", tool_sources=[fresh_handle.tools()])
+            await fresh.get_tool_lookups()
+            assert rotated.calls == 1
+            assert _InstrumentedAdapter.instances[-1].source.headers["Authorization"] == (
+                "Bearer rotated"
+            )
+            await fresh.close()
+
+    @pytest.mark.asyncio
+    async def test_a_same_configuration_rebind_does_not_reset_the_circuit(self) -> None:
+        _InstrumentedAdapter.connect_error = ConnectionError("server down")
+        async with MCPRuntime(
+            circuit_failure_threshold=1, circuit_reset_timeout=30.0, shutdown_timeout=0.05
+        ) as runtime:
+            connection = _bind(runtime)
+            agent = Agent(prompt="test", tool_sources=[connection.tools()])
+            with pytest.raises(ConnectionError):
+                await agent.get_tool_lookups()
+
+            # Applications naturally rebind per request; an identical bind
+            # must not hand a reconnect storm a fresh circuit.
+            rebound = _bind(runtime)
+            blocked = Agent(prompt="blocked", tool_sources=[rebound.tools()])
+            with pytest.raises(MCPCircuitOpenError):
+                await blocked.get_tool_lookups()
+            assert _total_connects() == 1
+
+    @pytest.mark.asyncio
+    async def test_cancelled_connection_attempts_do_not_count_as_failures(self) -> None:
+        gate = asyncio.Event()
+        _InstrumentedAdapter.connect_gate = gate
+        async with MCPRuntime(
+            circuit_failure_threshold=1,
+            circuit_reset_timeout=30.0,
+            idle_timeout=0.0,
+            shutdown_timeout=0.05,
+        ) as runtime:
+            connection = _bind(runtime)
+            acquisition = asyncio.create_task(runtime._lease(connection))
+            await _wait_until(lambda: _total_connects() == 1)
+            acquisition.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await acquisition
+            # Idle retirement cancels the abandoned connect task; that
+            # cancellation is not a verdict about the server's health.
+            await _wait_until(lambda: runtime._entries == {})
+
+            gate.set()
+            # The threshold is 1: any counted failure would open the circuit.
+            agent = Agent(prompt="test", tool_sources=[connection.tools()])
+            lookups = await agent.get_tool_lookups()
+            assert await lookups.fn["github__write"](value=1) == "write:ok"
+            await agent.close()
+
+    @pytest.mark.asyncio
+    async def test_process_exit_signals_do_not_count_as_connection_failures(self) -> None:
+        _InstrumentedAdapter.connect_error = SystemExit(3)
+        runtime = MCPRuntime(
+            circuit_failure_threshold=1,
+            circuit_reset_timeout=30.0,
+            shutdown_timeout=0.05,
+        )
+        connection = _bind(runtime)
+        entry = _ConnectionEntry(connection.source)
+        registration = runtime._registrations[(None, "github-1")]
+        entry.circuit = registration.circuit
+        runtime._entries[(None, "github-1")] = entry
+        runtime._bind_loop()
+
+        with pytest.raises(SystemExit):
+            await runtime._open_connection(
+                (None, "github-1"),
+                entry,
+                credentials=None,
+            )
+
+        assert registration.circuit.consecutive_failures == 0
+        assert registration.circuit.open_until is None
+        await runtime.close()
+
+    @pytest.mark.asyncio
+    async def test_process_exit_signal_during_call_does_not_reset_loss_streak(self) -> None:
+        _InstrumentedAdapter.call_error = SystemExit(3)
+        async with MCPRuntime(
+            circuit_failure_threshold=2,
+            circuit_reset_timeout=30.0,
+            shutdown_timeout=0.05,
+        ) as runtime:
+            connection = _bind(runtime)
+            agent = Agent(prompt="test", tool_sources=[connection.tools()])
+            lookups = await agent.get_tool_lookups()
+            circuit = runtime._registrations[(None, "github-1")].circuit
+            circuit.consecutive_failures = 1
+            circuit.connection_loss_failures = 1
+            circuit.last_failure = "connection loss"
+
+            with pytest.raises(SystemExit):
+                await lookups.fn["github__write"](value=1)
+
+            assert circuit.consecutive_failures == 1
+            assert circuit.connection_loss_failures == 1
+            await agent.close()
+
+    @pytest.mark.asyncio
+    async def test_shutdown_wins_over_an_open_circuit(self) -> None:
+        _InstrumentedAdapter.connect_error = ConnectionError("server down")
+        runtime = MCPRuntime(
+            circuit_failure_threshold=1, circuit_reset_timeout=30.0, shutdown_timeout=0.05
+        )
+        connection = _bind(runtime)
+        agent = Agent(prompt="test", tool_sources=[connection.tools()])
+        with pytest.raises(ConnectionError):
+            await agent.get_tool_lookups()
+        await runtime.close()
+
+        blocked = Agent(prompt="blocked", tool_sources=[connection.tools()])
+        with pytest.raises(MCPRuntimeClosedError):
+            await blocked.get_tool_lookups()
+        assert runtime.state is MCPRuntimeState.CLOSED
+
+    @pytest.mark.asyncio
+    async def test_the_circuit_can_be_disabled_entirely(self) -> None:
+        _InstrumentedAdapter.connect_error = ConnectionError("server down")
+        async with MCPRuntime(
+            circuit_failure_threshold=None, circuit_reset_timeout=30.0, shutdown_timeout=0.05
+        ) as runtime:
+            connection = _bind(runtime)
+            for _ in range(6):
+                agent = Agent(prompt="test", tool_sources=[connection.tools()])
+                with pytest.raises(ConnectionError):
+                    await agent.get_tool_lookups()
+            assert _total_connects() == 6
+            assert runtime._entries == {}
+
+    def test_circuit_configuration_is_validated(self) -> None:
+        with pytest.raises(ValueError, match="circuit_failure_threshold"):
+            MCPRuntime(circuit_failure_threshold=0)
+        with pytest.raises(ValueError, match="circuit_failure_threshold"):
+            MCPRuntime(circuit_failure_threshold=True)
+        with pytest.raises(ValueError, match="circuit_reset_timeout"):
+            MCPRuntime(circuit_reset_timeout=0)
+        with pytest.raises(ValueError, match="circuit_reset_timeout"):
+            MCPRuntime(circuit_reset_timeout=-1.0)


### PR DESCRIPTION
## Summary

- detect transport and official MCP SDK session-loss failures, fence dead shared connections, and lazily reconnect with fresh credentials
- distinguish unknown outcomes for admitted calls from retry-safe failures for calls that were never sent
- interrupt sibling calls safely, preserve application cancellation ownership, and reclaim capacity from resistant transports
- add per-identity circuit breaking with bounded cooldown and one single-flight half-open probe
- isolate breaker state by tenant/connection identity and prevent obsolete connection attempts from overwriting current health
- accumulate repeated mid-call losses until a confirmed tool response proves the replacement session healthy

## Runtime behavior

- no MCP tool call is automatically retried
- eviction and changed source configuration or `credential_identity` reset the circuit
- live connections and unrelated tenant partitions are unaffected
- cancellation and process-exit signals do not change breaker health
- credential values remain absent from circuit errors and logs

## Validation

- `make ci`
- 1,985 passed, 250 skipped
- 92.20% overall coverage
- 99% coverage for `dendrux.mcp._runtime`
- Ruff, formatting, mypy, and `git diff --check` clean

Follow-up to #48.